### PR TITLE
Fix Windows bundled marketplace sync from WindowsApps paths

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -202,6 +202,12 @@ Remove-Item Env:ELECTRON_ENABLE_LOGGING -ErrorAction SilentlyContinue
 - If the Computer Control page says `Computer Use 插件不可用`, check the Desktop log for `computer-use native pipe startup failed` with `missing-helper-path`, then inspect `$env:USERPROFILE\.codex\.tmp\bundled-marketplaces\openai-bundled\.agents\plugins\marketplace.json` and `plugins\computer-use`. If they are missing or partial, stop bundled `extension-host` processes under `$env:USERPROFILE\.codex\plugins\cache\openai-bundled`, rerun `scripts\install-computer-use-local.ps1`, restart Codex Desktop, and confirm the log ends with `computer-use native pipe startup ready`.
 - If `scripts\install-computer-use-local.ps1 -StrictVerifyOnly` fails because `$env:USERPROFILE\.codex\plugins\cache\openai-bundled\computer-use\latest\.codex-plugin\plugin.json` is missing, run the same script with `-VerifyOnly` to repair the marketplace mirror, cached plugin copy, and `latest` link, then rerun `-StrictVerifyOnly`.
 - If the failure reappears after fully quitting and reopening Codex Desktop, inspect `$env:USERPROFILE\.codex\chrome-native-hosts.json` and the real targets of `$env:USERPROFILE\.codex\plugins\cache\openai-bundled\chrome\latest` and `browser\latest`. Stale Chrome native-host entries, or a `chrome\latest` junction that points at `$env:USERPROFILE\.codex\.tmp\bundled-marketplaces\openai-bundled\plugins\chrome`, can let Chrome native messaging lock the mutable marketplace mirror. The symptom is `bundled_plugins_marketplace_resolve_failed` with `EBUSY` on `plugins\chrome\extension-host\windows\x64`, followed by `helper paths changed` and `missing-helper-path`; rerun `scripts\install-computer-use-local.ps1` to stop the lock holder, rebuild stable browser/chrome cache copies, repoint the Chrome native messaging manifest to the stable cache path, and repair Computer Use.
+- If the failure reappears after restart with `plugin_marketplace_folder_write_failed` during `copy_plugins`, `bundled_plugins_marketplace_resolve_failed`, or `not_in_bundled_marketplace_plugin_names` uninstalling `browser@openai-bundled` / `chrome@openai-bundled`, patch only the bundled marketplace copy helper instead of running the full Fast/browser/Computer Use gate repatch:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\patch_codex_fast_mode_windows_msix.ps1" -OnlyBundledMarketplaceCopy -DryRun -OutputRoot "<large-local-build-root>"
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\patch_codex_fast_mode_windows_msix.ps1" -OnlyBundledMarketplaceCopy -Install -Launch -InstallPrerequisites -OutputRoot "<large-local-build-root>"
+```
 
 ## Useful Wrapper Options
 
@@ -210,6 +216,7 @@ Remove-Item Env:ELECTRON_ENABLE_LOGGING -ErrorAction SilentlyContinue
 - `-SkipFastVerify`: skip the WebSocket `service_tier` capture.
 - `-KeepBuild`: keep `Downloads\codex-msix-repack` for debugging.
 - `-OutputRoot <path>`: optional large local build root; use it when the default output root is short on space, points at a broken junction, or should be kept off the system drive.
+- `-OnlyBundledMarketplaceCopy`: patch only the Desktop bundled marketplace copy helper so Windows falls back to byte-stream copying when `fs.cp()` cannot copy bundled plugin files from WindowsApps-protected package paths. Use this for restart-time bundled marketplace sync failures that uninstall `browser` or `chrome`, not for general Fast Mode or UI gates.
 - `-SkipSdkCleanup`: leave Windows SDK installed.
 - `-RegisterMarketplaceOnly`: only register `openai-curated-local`; do not patch Codex.
 - `-PatchScript <path>`: override the bundled patch script only when testing a newer patcher.

--- a/scripts/install-computer-use-local.ps1
+++ b/scripts/install-computer-use-local.ps1
@@ -107,6 +107,38 @@ function Remove-ReparsePointOrDirectory {
   Remove-Item -LiteralPath $item.FullName -Recurse -Force
 }
 
+function Copy-DirectoryDataOnly {
+  param(
+    [string]$Source,
+    [string]$Destination
+  )
+
+  if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
+    throw "copy source directory not found: $Source"
+  }
+
+  if (Test-Path -LiteralPath $Destination) {
+    Remove-ReparsePointOrDirectory $Destination
+  }
+
+  $sourceRoot = (Resolve-Path -LiteralPath $Source).ProviderPath
+  Resolve-OrCreateDirectory $Destination | Out-Null
+
+  foreach ($dir in Get-ChildItem -LiteralPath $sourceRoot -Recurse -Directory -Force) {
+    $relative = $dir.FullName.Substring($sourceRoot.Length).TrimStart('\')
+    Resolve-OrCreateDirectory (Join-Path $Destination $relative) | Out-Null
+  }
+
+  foreach ($file in Get-ChildItem -LiteralPath $sourceRoot -Recurse -File -Force) {
+    $relative = $file.FullName.Substring($sourceRoot.Length).TrimStart('\')
+    $target = Join-Path $Destination $relative
+    $targetParent = Split-Path -Parent $target
+    Resolve-OrCreateDirectory $targetParent | Out-Null
+    [System.IO.File]::WriteAllBytes($target, [System.IO.File]::ReadAllBytes($file.FullName))
+    [System.IO.File]::SetLastWriteTime($target, $file.LastWriteTime)
+  }
+}
+
 function Set-TomlTable {
   param(
     [string]$ConfigPath,
@@ -555,15 +587,10 @@ function Patch-ComputerUseClientScript {
     return
   }
 
-  $usesNodeReplRuntimePath = $content.Contains('getWindowsComputerUseClientBasePath()') -and $content.Contains('NODE_REPL_NODE_MODULE_DIRS')
-  if ($usesNodeReplRuntimePath) {
-    Write-Log "Computer Use client already resolves Windows runtime through nodeRepl env: $ClientPath"
-    return
-  }
-
   $oldImport = 'import { WindowsComputerUseClientBase } from "@oai/sky/dist/project/cua/sky_js/src/targets/windows/internal/computer_use_client_base.js";'
   if (-not $content.Contains($oldImport)) {
-    throw "Computer Use client import anchor not found in: $ClientPath"
+    Write-Log "Computer Use client import anchor not found; leaving client script unchanged: $ClientPath"
+    return
   }
 
   $replacement = @'
@@ -628,10 +655,7 @@ function Write-PluginTree {
   if (Test-Path -LiteralPath $distPath) {
     Remove-ReparsePointOrDirectory $distPath
   }
-  & robocopy.exe $runtimeDistPath $distPath /MIR /NFL /NDL /NJH /NJS /NP | Out-Null
-  if ($LASTEXITCODE -gt 7) {
-    throw "robocopy failed while overlaying Computer Use @oai/sky runtime files (exit code $LASTEXITCODE)"
-  }
+  Copy-DirectoryDataOnly $runtimeDistPath $distPath
 
   ConvertTo-JsonFile $packagePath ([ordered]@{
     name = '@oai/sky'
@@ -650,7 +674,7 @@ function Update-BundledMarketplaceManifest {
 
   $manifestPath = Join-Path $MarketplaceRoot '.agents\plugins\marketplace.json'
   if (Test-Path -LiteralPath $manifestPath) {
-    $json = Get-Content -Raw -LiteralPath $manifestPath | ConvertFrom-Json
+    $json = Get-Content -Raw -Encoding UTF8 -LiteralPath $manifestPath | ConvertFrom-Json
   } else {
     $json = [pscustomobject]@{
       name = 'openai-bundled'
@@ -697,6 +721,12 @@ function Update-CodexConfig {
   Set-TomlTable $configPath '[plugins."computer-use@openai-bundled"]' @{
     enabled = $true
   }
+  Set-TomlTable $configPath '[plugins."browser@openai-bundled"]' @{
+    enabled = $true
+  }
+  Set-TomlTable $configPath '[plugins."chrome@openai-bundled"]' @{
+    enabled = $true
+  }
   Set-TomlTable $configPath '[windows]' @{
     sandbox = 'unelevated'
   }
@@ -737,18 +767,34 @@ tomllib.loads(path.read_text(encoding="utf-8"))
 
 function Get-CuaSkyRuntimeRoot {
   $runtimeRoot = Join-Path $env:LOCALAPPDATA 'OpenAI\Codex\runtimes\cua_node'
-  if (-not (Test-Path -LiteralPath $runtimeRoot -PathType Container)) {
-    throw "Codex CUA runtime root is missing: $runtimeRoot"
+  $candidates = @()
+
+  if (Test-Path -LiteralPath $runtimeRoot -PathType Container) {
+    $candidates += foreach ($runtime in (Get-ChildItem -LiteralPath $runtimeRoot -Directory -ErrorAction SilentlyContinue)) {
+      $skyRoot = Join-Path $runtime.FullName 'bin\node_modules\@oai\sky'
+      $basePath = Join-Path $skyRoot 'dist\project\cua\sky_js\src\targets\windows\internal\computer_use_client_base.js'
+      $packagePath = Join-Path $skyRoot 'package.json'
+      if ((Test-Path -LiteralPath $basePath -PathType Leaf) -and (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+        $packageItem = Get-Item -LiteralPath $packagePath
+        [pscustomobject]@{
+          Path = $skyRoot
+          LastWriteTime = $packageItem.LastWriteTime
+        }
+      }
+    }
   }
 
-  $candidates = foreach ($runtime in (Get-ChildItem -LiteralPath $runtimeRoot -Directory -ErrorAction SilentlyContinue)) {
-    $skyRoot = Join-Path $runtime.FullName 'bin\node_modules\@oai\sky'
-    $basePath = Join-Path $skyRoot 'dist\project\cua\sky_js\src\targets\windows\internal\computer_use_client_base.js'
-    $packagePath = Join-Path $skyRoot 'package.json'
-    if ((Test-Path -LiteralPath $basePath -PathType Leaf) -and (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
+  $pkg = Get-AppxPackage -Name OpenAI.Codex -ErrorAction SilentlyContinue |
+    Sort-Object Version -Descending |
+    Select-Object -First 1
+  if ($pkg) {
+    $packageSkyRoot = Join-Path $pkg.InstallLocation 'app\resources\cua_node\bin\node_modules\@oai\sky'
+    $packageBasePath = Join-Path $packageSkyRoot 'dist\project\cua\sky_js\src\targets\windows\internal\computer_use_client_base.js'
+    $packagePath = Join-Path $packageSkyRoot 'package.json'
+    if ((Test-Path -LiteralPath $packageBasePath -PathType Leaf) -and (Test-Path -LiteralPath $packagePath -PathType Leaf)) {
       $packageItem = Get-Item -LiteralPath $packagePath
-      [pscustomobject]@{
-        Path = $skyRoot
+      $candidates += [pscustomobject]@{
+        Path = $packageSkyRoot
         LastWriteTime = $packageItem.LastWriteTime
       }
     }
@@ -756,7 +802,7 @@ function Get-CuaSkyRuntimeRoot {
 
   $selected = @($candidates | Sort-Object LastWriteTime -Descending | Select-Object -First 1)
   if ($selected.Count -eq 0) {
-    throw "no usable Codex CUA @oai/sky runtime was found under $runtimeRoot"
+    throw "no usable Codex CUA @oai/sky runtime was found under $runtimeRoot or the installed Codex package"
   }
 
   return $selected[0].Path
@@ -910,10 +956,7 @@ function Sync-OpenAiBundledPluginCache {
   }
 
   Write-Log "syncing bundled plugin cache: $PluginName@$version"
-  & robocopy.exe $sourcePluginRoot $cacheVersionRoot /MIR /NFL /NDL /NJH /NJS /NP | Out-Null
-  if ($LASTEXITCODE -gt 7) {
-    throw "robocopy failed while caching ${PluginName} (exit code $LASTEXITCODE)"
-  }
+  Copy-DirectoryDataOnly $sourcePluginRoot $cacheVersionRoot
 
   if (Test-Path -LiteralPath $latestPath) {
     Remove-ReparsePointOrDirectory $latestPath
@@ -934,7 +977,16 @@ function Update-ChromeNativeMessagingManifest {
 
   $manifestPath = Join-Path $env:LOCALAPPDATA 'OpenAI\extension\com.openai.codexextension.json'
   if (-not (Test-Path -LiteralPath $manifestPath -PathType Leaf)) {
-    Write-Log "warning: Chrome native messaging manifest not found: $manifestPath"
+    $json = [PSCustomObject]@{
+      allowed_origins = @('chrome-extension://hehggadaopoacecdllhhajmbjkdcmajg/')
+      description = 'Codex chrome native messaging host'
+      name = 'com.openai.codexextension'
+      path = $hostExe
+      type = 'stdio'
+    }
+    ConvertTo-JsonFile $manifestPath $json
+    & reg.exe add 'HKCU\Software\Google\Chrome\NativeMessagingHosts\com.openai.codexextension' /ve /t REG_SZ /d $manifestPath /f | Out-Null
+    Write-Log "created Chrome native messaging manifest: $manifestPath"
     return
   }
 
@@ -953,6 +1005,7 @@ function Update-ChromeNativeMessagingManifest {
   Copy-Item -LiteralPath $manifestPath -Destination $backupPath -Force
   $json.path = $hostExe
   ConvertTo-JsonFile $manifestPath $json
+  & reg.exe add 'HKCU\Software\Google\Chrome\NativeMessagingHosts\com.openai.codexextension' /ve /t REG_SZ /d $manifestPath /f | Out-Null
   Write-Log "updated Chrome native messaging manifest: $manifestPath"
   Write-Log "Chrome native messaging manifest backup: $backupPath"
 }
@@ -970,10 +1023,7 @@ function Sync-BundledMarketplaceFromInstalledApp {
   )
 
   Write-Log "syncing installed openai-bundled marketplace: $sourceRoot -> $MarketplaceRoot"
-  & robocopy.exe $sourceRoot $MarketplaceRoot /MIR /NFL /NDL /NJH /NJS /NP | Out-Null
-  if ($LASTEXITCODE -gt 7) {
-    throw "robocopy failed while syncing openai-bundled marketplace (exit code $LASTEXITCODE)"
-  }
+  Copy-DirectoryDataOnly $sourceRoot $MarketplaceRoot
 }
 
 function Test-BundledMarketplaceMirror {
@@ -1029,6 +1079,12 @@ function Test-CodexConfig {
     if ($content -notmatch '(?ms)^\[plugins\."computer-use@openai-bundled"\]\s*\r?\n(?:(?!^\[).)*enabled\s*=\s*true') {
       throw 'config.toml is missing plugins."computer-use@openai-bundled".enabled=true'
     }
+    if ($content -notmatch '(?ms)^\[plugins\."browser@openai-bundled"\]\s*\r?\n(?:(?!^\[).)*enabled\s*=\s*true') {
+      throw 'config.toml is missing plugins."browser@openai-bundled".enabled=true'
+    }
+    if ($content -notmatch '(?ms)^\[plugins\."chrome@openai-bundled"\]\s*\r?\n(?:(?!^\[).)*enabled\s*=\s*true') {
+      throw 'config.toml is missing plugins."chrome@openai-bundled".enabled=true'
+    }
     if ($content -notmatch '(?ms)^\[windows\]\s*\r?\n(?:(?!^\[).)*sandbox\s*=\s*[''"]unelevated[''"]') {
       throw 'config.toml is missing windows.sandbox=unelevated'
     }
@@ -1058,11 +1114,19 @@ else:
     if marketplace.get("source") != expected_source:
         errors.append("marketplaces.openai-bundled.source does not point at the local bundled marketplace")
 
-plugin = data.get("plugins", {}).get("computer-use@openai-bundled")
+plugins = data.get("plugins", {})
+plugin = plugins.get("computer-use@openai-bundled")
 if not isinstance(plugin, dict):
     errors.append('missing [plugins."computer-use@openai-bundled"]')
 elif plugin.get("enabled") is not True:
     errors.append('plugins."computer-use@openai-bundled".enabled must be true')
+
+for plugin_id in ("browser@openai-bundled", "chrome@openai-bundled"):
+    plugin = plugins.get(plugin_id)
+    if not isinstance(plugin, dict):
+        errors.append(f'missing [plugins."{plugin_id}"]')
+    elif plugin.get("enabled") is not True:
+        errors.append(f'plugins."{plugin_id}".enabled must be true')
 
 windows = data.get("windows", {})
 if not isinstance(windows, dict):
@@ -1152,10 +1216,14 @@ function Test-ComputerUseClientImport {
     throw 'node.exe not found; cannot verify Computer Use client import'
   }
 
-  $runtimeSkyRoot = Get-CuaSkyRuntimeRoot
-  $runtimeNodeModules = Split-Path -Parent (Split-Path -Parent $runtimeSkyRoot)
+  $clientRoot = Split-Path -Parent (Split-Path -Parent $ClientPath)
+  $runtimeNodeModules = Join-Path $clientRoot 'node_modules'
   if (-not (Test-Path -LiteralPath $runtimeNodeModules -PathType Container)) {
-    throw "Unable to locate CUA runtime node_modules for import verification: $runtimeNodeModules"
+    $runtimeSkyRoot = Get-CuaSkyRuntimeRoot
+    $runtimeNodeModules = Split-Path -Parent (Split-Path -Parent $runtimeSkyRoot)
+    if (-not (Test-Path -LiteralPath $runtimeNodeModules -PathType Container)) {
+      throw "Unable to locate CUA runtime node_modules for import verification: $runtimeNodeModules"
+    }
   }
 
   $script = @'
@@ -1163,10 +1231,11 @@ import { pathToFileURL } from "node:url";
 
 globalThis.nodeRepl = {
   config: {},
-  env: {
-    NODE_REPL_NODE_MODULE_DIRS: process.argv[3],
-  },
   nativePipe: {},
+  env: {
+    NODE_REPL_NODE_MODULE_DIRS:
+      process.env.NODE_REPL_NODE_MODULE_DIRS ?? process.env.NODE_PATH ?? "",
+  },
 };
 
 const mod = await import(pathToFileURL(process.argv[2]).href);
@@ -1178,6 +1247,7 @@ console.log(JSON.stringify({ ok: true, exports: Object.keys(mod).sort() }));
   $temp = Join-Path $env:TEMP ('codex-computer-use-client-import-' + [guid]::NewGuid().ToString('N') + '.mjs')
   $tempClient = Join-Path $env:TEMP ('codex-computer-use-client-copy-' + [guid]::NewGuid().ToString('N') + '.mjs')
   $oldNodePath = [Environment]::GetEnvironmentVariable('NODE_PATH', 'Process')
+  $oldNodeReplNodeModuleDirs = [Environment]::GetEnvironmentVariable('NODE_REPL_NODE_MODULE_DIRS', 'Process')
   try {
     Write-Utf8NoBom $temp $script
     Copy-Item -LiteralPath $ClientPath -Destination $tempClient -Force
@@ -1185,7 +1255,8 @@ console.log(JSON.stringify({ ok: true, exports: Object.keys(mod).sort() }));
     # The Codex Node REPL resolves bare packages from runtime search roots, not
     # from the imported plugin file's local node_modules. Verify that shape.
     [Environment]::SetEnvironmentVariable('NODE_PATH', $runtimeNodeModules, 'Process')
-    $output = & $node.Source $temp $tempClient $runtimeNodeModules
+    [Environment]::SetEnvironmentVariable('NODE_REPL_NODE_MODULE_DIRS', $runtimeNodeModules, 'Process')
+    $output = & $node.Source $temp $tempClient
     if ($LASTEXITCODE -ne 0) {
       throw "Computer Use client import verification failed for $ClientPath"
     }
@@ -1197,6 +1268,11 @@ console.log(JSON.stringify({ ok: true, exports: Object.keys(mod).sort() }));
       Remove-Item Env:\NODE_PATH -ErrorAction SilentlyContinue
     } else {
       [Environment]::SetEnvironmentVariable('NODE_PATH', $oldNodePath, 'Process')
+    }
+    if ($null -eq $oldNodeReplNodeModuleDirs) {
+      Remove-Item Env:\NODE_REPL_NODE_MODULE_DIRS -ErrorAction SilentlyContinue
+    } else {
+      [Environment]::SetEnvironmentVariable('NODE_REPL_NODE_MODULE_DIRS', $oldNodeReplNodeModuleDirs, 'Process')
     }
     Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $tempClient -Force -ErrorAction SilentlyContinue
@@ -1295,7 +1371,7 @@ function Test-ComputerUse {
   }
 
   if (Test-Path -LiteralPath $chromeNativeManifest -PathType Leaf) {
-    $nativeManifest = Get-Content -Raw -LiteralPath $chromeNativeManifest | ConvertFrom-Json
+    $nativeManifest = Get-Content -Raw -Encoding UTF8 -LiteralPath $chromeNativeManifest | ConvertFrom-Json
     if ([string]$nativeManifest.path -ne $chromeHostPath) {
       throw "Chrome native messaging manifest does not point at stable cache path: $chromeNativeManifest"
     }

--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -13,6 +13,7 @@ param(
   [string]$LocalPluginMarketplaceSource = (Join-Path $env:USERPROFILE '.codex\.tmp\plugins'),
   [string]$LocalPluginMarketplaceName = 'openai-curated-local',
   [switch]$VerifyFastModeRequest,
+  [switch]$OnlyBundledMarketplaceCopy,
   [switch]$DryRun
 )
 
@@ -349,6 +350,53 @@ function Require-WindowsSdkTool {
   return [string]$tool
 }
 
+function Copy-FileDataOnly {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination
+  )
+  New-Item -ItemType Directory -Force -Path (Split-Path -Parent $Destination) | Out-Null
+  $inputStream = [System.IO.File]::Open($Source, [System.IO.FileMode]::Open, [System.IO.FileAccess]::Read, [System.IO.FileShare]::ReadWrite -bor [System.IO.FileShare]::Delete)
+  try {
+    $outputStream = [System.IO.File]::Open($Destination, [System.IO.FileMode]::Create, [System.IO.FileAccess]::Write, [System.IO.FileShare]::None)
+    try {
+      $inputStream.CopyTo($outputStream)
+    } finally {
+      $outputStream.Dispose()
+    }
+  } finally {
+    $inputStream.Dispose()
+  }
+  try {
+    $sourceItem = Get-Item -LiteralPath $Source -Force
+    [System.IO.File]::SetLastWriteTimeUtc($Destination, $sourceItem.LastWriteTimeUtc)
+  } catch {
+    Write-Log "warning: could not preserve timestamp for $Destination`: $($_.Exception.Message)"
+  }
+}
+
+function Copy-DirectoryDataOnly {
+  param(
+    [Parameter(Mandatory = $true)][string]$Source,
+    [Parameter(Mandatory = $true)][string]$Destination
+  )
+  if (-not (Test-Path -LiteralPath $Source -PathType Container)) {
+    Fail "source directory not found: $Source"
+  }
+  New-Item -ItemType Directory -Force -Path $Destination | Out-Null
+  foreach ($item in Get-ChildItem -LiteralPath $Source -Force) {
+    $target = Join-Path $Destination $item.Name
+    if ($item.PSIsContainer -and (($item.Attributes -band [System.IO.FileAttributes]::ReparsePoint) -eq 0)) {
+      Copy-DirectoryDataOnly -Source $item.FullName -Destination $target
+    } elseif ($item.PSIsContainer) {
+      Write-Log "warning: copying reparse directory as an empty directory: $($item.FullName)"
+      New-Item -ItemType Directory -Force -Path $target | Out-Null
+    } else {
+      Copy-FileDataOnly -Source $item.FullName -Destination $target
+    }
+  }
+}
+
 function Copy-PackageLayout {
   param(
     [string]$SourcePackageRoot,
@@ -360,9 +408,22 @@ function Copy-PackageLayout {
   if (-not (Test-Path -LiteralPath $WorkPackageRoot)) {
     New-Item -ItemType Directory -Force -Path $WorkPackageRoot | Out-Null
     Write-Log "copying package layout to: $WorkPackageRoot"
+    $asarPath = Join-Path $WorkPackageRoot 'app\resources\app.asar'
+    $robocopyFailed = $false
     & robocopy.exe $SourcePackageRoot $WorkPackageRoot /MIR /R:2 /W:1 /NFL /NDL /NJH /NJS /NP | Out-Null
     if ($LASTEXITCODE -gt 7) {
-      Fail "robocopy failed with exit code $LASTEXITCODE"
+      Write-Log "warning: robocopy failed with exit code $LASTEXITCODE; retrying package copy with data-only stream copy"
+      $robocopyFailed = $true
+    }
+    if ($robocopyFailed -or -not (Test-Path -LiteralPath $asarPath -PathType Leaf)) {
+      if (Test-Path -LiteralPath $WorkPackageRoot) {
+        Remove-DirectoryRobust -Path $WorkPackageRoot -RequiredRoot (Split-Path -Parent $WorkPackageRoot)
+      }
+      New-Item -ItemType Directory -Force -Path $WorkPackageRoot | Out-Null
+      Copy-DirectoryDataOnly -Source $SourcePackageRoot -Destination $WorkPackageRoot
+    }
+    if (-not (Test-Path -LiteralPath $asarPath -PathType Leaf)) {
+      Fail "package copy did not produce app.asar: $asarPath"
     }
   } else {
     Write-Log "using existing work package layout: $WorkPackageRoot"
@@ -427,6 +488,7 @@ function Write-PatcherFiles {
   $goalPatcherPath = Join-Path $WorkDir 'PatchGoal.cjs'
   $computerUsePatcherPath = Join-Path $WorkDir 'PatchComputerUseGates.cjs'
   $browserUsePatcherPath = Join-Path $WorkDir 'PatchBrowserUseGates.cjs'
+  $bundledMarketplaceCopyPatcherPath = Join-Path $WorkDir 'PatchBundledMarketplaceCopy.cjs'
 
   Set-Content -LiteralPath $fastPatcherPath -Encoding UTF8 -Value @'
 const fs = require('node:fs');
@@ -953,6 +1015,29 @@ patchDesktopFeatureMain(desktopFeatureMainFile);
 process.stdout.write(changed ? 'patched' : 'already-patched');
 '@
 
+  Set-Content -LiteralPath $bundledMarketplaceCopyPatcherPath -Encoding UTF8 -Value @'
+const fs = require('node:fs');
+const file = process.argv[2];
+const text = fs.readFileSync(file, 'utf8');
+
+const patchedMarker = 'codex_windows_bundled_marketplace_copy_fallback';
+if (text.includes(patchedMarker)) {
+  process.stdout.write('already-patched');
+  process.exit(0);
+}
+
+const original = 'async function Bs(e,t){if(m.default.platform===`darwin`){await Ko(`ditto`,[`--noqtn`,e,t]);return}await f.default.cp(e,t,{recursive:!0,verbatimSymlinks:!0})}';
+const replacement = 'async function Bs(e,t){if(m.default.platform===`darwin`){await Ko(`ditto`,[`--noqtn`,e,t]);return}try{await f.default.cp(e,t,{recursive:!0,verbatimSymlinks:!0});return}catch(n){if(m.default.platform!==`win32`)throw n;L.warning(`codex_windows_bundled_marketplace_copy_fallback`,{safe:{},sensitive:{error:n,source:e,target:t}})}async function n(e,t){let r=await f.default.lstat(e);if(r.isDirectory()){await f.default.mkdir(t,{recursive:!0});for(let r of await f.default.readdir(e))await n((0,s.join)(e,r),(0,s.join)(t,r));return}if(r.isSymbolicLink()){let n=await f.default.readlink(e);try{await f.default.symlink(n,t)}catch(e){if(e?.code!==`EEXIST`)throw e}return}await f.default.mkdir((0,s.dirname)(t),{recursive:!0});let i=await f.default.readFile(e);await f.default.writeFile(t,i);try{await f.default.chmod(t,r.mode)}catch{}}await n(e,t)}';
+
+if (!text.includes(original)) {
+  process.stderr.write('bundled-marketplace-copy-target-not-found\n');
+  process.exit(2);
+}
+
+fs.writeFileSync(file, text.replace(original, replacement));
+process.stdout.write('patched');
+'@
+
   return [pscustomobject]@{
     Fast = $fastPatcherPath
     FastUi = $fastUiPatcherPath
@@ -961,6 +1046,7 @@ process.stdout.write(changed ? 'patched' : 'already-patched');
     Goal = $goalPatcherPath
     ComputerUse = $computerUsePatcherPath
     BrowserUse = $browserUsePatcherPath
+    BundledMarketplaceCopy = $bundledMarketplaceCopyPatcherPath
   }
 }
 
@@ -1217,6 +1303,18 @@ function Find-PatchTargets {
     Fail 'could not find Computer Use setup gate in extracted assets'
   }
 
+  $bundledMarketplaceCopyTarget = $null
+  foreach ($candidate in (Get-ChildItem -LiteralPath $viteBuildDir -Filter '*.js' -File -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)) {
+    $text = Get-Content -Raw -LiteralPath $candidate
+    if (($text.Contains('plugin_marketplace_folder_write_failed') -and $text.Contains('async function Bs(e,t)')) -or $text.Contains('codex_windows_bundled_marketplace_copy_fallback')) {
+      $bundledMarketplaceCopyTarget = $candidate
+      break
+    }
+  }
+  if ([string]::IsNullOrWhiteSpace($bundledMarketplaceCopyTarget)) {
+    Fail 'could not find bundled marketplace copy helper in extracted main bundle'
+  }
+
   Write-Log "fast-mode patch target: $fastModeTarget"
   Write-Log "fast-mode UI patch target: $fastModeUiTarget"
   Write-Log "locale i18n patch target: $localeI18nTarget"
@@ -1233,6 +1331,7 @@ function Find-PatchTargets {
   Write-Log "computer-use availability patch target: $computerUseAvailabilityTarget"
   Write-Log "computer-use install-flow patch target: $computerUseInstallFlowTarget"
   Write-Log "computer-use setup patch target: $computerUseSetupTarget"
+  Write-Log "bundled marketplace copy patch target: $bundledMarketplaceCopyTarget"
 
   return [pscustomobject]@{
     FastMode = $fastModeTarget
@@ -1251,6 +1350,7 @@ function Find-PatchTargets {
     ComputerUseAvailability = $computerUseAvailabilityTarget
     ComputerUseInstallFlow = $computerUseInstallFlowTarget
     ComputerUseSetup = $computerUseSetupTarget
+    BundledMarketplaceCopy = $bundledMarketplaceCopyTarget
   }
 }
 
@@ -1291,6 +1391,41 @@ function Invoke-PatchAppAsar {
   Write-Log 'extracting app.asar'
   Invoke-NpxAsar 'extract' $asarPath $extractDir
   $patchers = Write-PatcherFiles $WorkDir
+
+  if ($OnlyBundledMarketplaceCopy) {
+    $viteBuildDir = Join-Path $extractDir '.vite\build'
+    if (-not (Test-Path -LiteralPath $viteBuildDir -PathType Container)) {
+      Fail "vite build directory not found in extracted asar: $viteBuildDir"
+    }
+    $bundledMarketplaceCopyTarget = $null
+    foreach ($candidate in (Get-ChildItem -LiteralPath $viteBuildDir -Filter '*.js' -File -ErrorAction SilentlyContinue | Select-Object -ExpandProperty FullName)) {
+      $text = Get-Content -Raw -LiteralPath $candidate
+      if (($text.Contains('plugin_marketplace_folder_write_failed') -and $text.Contains('async function Bs(e,t)')) -or $text.Contains('codex_windows_bundled_marketplace_copy_fallback')) {
+        $bundledMarketplaceCopyTarget = $candidate
+        break
+      }
+    }
+    if ([string]::IsNullOrWhiteSpace($bundledMarketplaceCopyTarget)) {
+      Fail 'could not find bundled marketplace copy helper in extracted main bundle'
+    }
+    Write-Log "bundled marketplace copy patch target: $bundledMarketplaceCopyTarget"
+    $bundledMarketplaceCopy = Invoke-NodePatcher $nodePath $patchers.BundledMarketplaceCopy @($bundledMarketplaceCopyTarget)
+    Write-Log "bundled marketplace copy patch result: $bundledMarketplaceCopy"
+
+    if ($DryRun) {
+      Write-Log 'dry run: bundled marketplace copy patch target validation completed; no package was changed'
+      return $false
+    }
+    if ($bundledMarketplaceCopy -eq 'already-patched') {
+      Write-Log 'asar bundled marketplace copy patch already present'
+      return $false
+    }
+    Write-Log 'repacking app.asar'
+    Invoke-NpxAsar 'pack' $extractDir $newAsarPath
+    Copy-Item -LiteralPath $newAsarPath -Destination $asarPath -Force
+    return $true
+  }
+
   $targets = Find-PatchTargets $rgPath $extractDir
 
   $fast = Invoke-NodePatcher $nodePath $patchers.Fast @($targets.FastMode)
@@ -1319,6 +1454,8 @@ function Invoke-PatchAppAsar {
   )
   $computerUse = Invoke-NodePatcher $nodePath $patchers.ComputerUse $computerUseArgs
   Write-Log "computer-use gate patch result: $computerUse"
+  $bundledMarketplaceCopy = Invoke-NodePatcher $nodePath $patchers.BundledMarketplaceCopy @($targets.BundledMarketplaceCopy)
+  Write-Log "bundled marketplace copy patch result: $bundledMarketplaceCopy"
 
   if ($DryRun) {
     Write-Log 'dry run: patch target validation completed; no package was changed'
@@ -1331,7 +1468,8 @@ function Invoke-PatchAppAsar {
       $plugins -eq 'already-patched' -and
       $goal -eq 'already-patched' -and
       $browserUse -eq 'already-patched' -and
-      $computerUse -eq 'already-patched') {
+      $computerUse -eq 'already-patched' -and
+      $bundledMarketplaceCopy -eq 'already-patched') {
     Write-Log 'asar patch already present'
     return $false
   }
@@ -1445,8 +1583,10 @@ function Trust-SigningCertificate {
   param([System.Security.Cryptography.X509Certificates.X509Certificate2]$Cert)
   $tempCert = Join-Path $env:TEMP ('codex-msix-signing-' + $Cert.Thumbprint + '.cer')
   Export-Certificate -Cert $Cert -FilePath $tempCert -Force | Out-Null
+  Import-Certificate -FilePath $tempCert -CertStoreLocation Cert:\CurrentUser\Root | Out-Null
   Import-Certificate -FilePath $tempCert -CertStoreLocation Cert:\CurrentUser\TrustedPeople | Out-Null
   if (Test-IsAdministrator) {
+    Import-Certificate -FilePath $tempCert -CertStoreLocation Cert:\LocalMachine\Root | Out-Null
     Import-Certificate -FilePath $tempCert -CertStoreLocation Cert:\LocalMachine\TrustedPeople | Out-Null
   }
   Remove-Item -LiteralPath $tempCert -Force -ErrorAction SilentlyContinue


### PR DESCRIPTION
## Problem

On Windows Store/MSIX installs, Codex Desktop can repeatedly lose bundled plugins after a full app restart even after the local plugin cache has been repaired.

Observed symptoms include:

- `plugin_marketplace_folder_write_failed` during bundled marketplace `copy_plugins`
- `bundled_plugins_marketplace_resolve_failed`
- `bundled_plugin_uninstall_requested` with `reason=not_in_bundled_marketplace_plugin_names`
- `browser@openai-bundled` / `chrome@openai-bundled` being removed or marked not installed after restart
- local repair via `install-computer-use-local.ps1 -VerifyOnly` temporarily restores the plugin cache, but the failure can recur on the next Desktop startup

This creates a loop where the local `.codex` marketplace/cache state can be repaired, then Codex Desktop's startup-time bundled marketplace sync breaks it again.

## Root Cause

The Desktop bundled marketplace sync copies bundled plugin files from the installed package resources under `C:\Program Files\WindowsApps\...` into the runtime mirror under `.codex\.tmp\bundled-marketplaces\openai-bundled`.

In the affected WindowsApps/AppX-protected package path, Node's `fs.cp()` can fail while copying plugin files from the installed package. Once that copy fails, the runtime bundled marketplace mirror is incomplete. The later reconciliation logic then interprets missing bundled plugin names as removed from the bundled marketplace and uninstalls managed bundled plugins such as `browser` and `chrome`.

This is not fixed permanently by rebuilding the user cache alone, because the failing copy path lives in the Desktop ASAR code and is executed again at startup.

## Changes

### 1. Add a narrow MSIX patch mode for bundled marketplace copy failures

Adds `-OnlyBundledMarketplaceCopy` to `patch_codex_fast_mode_windows_msix.ps1`.

This mode:

- extracts `app.asar`
- locates the main-process bundled marketplace copy helper by scanning `.vite\build\*.js`
- patches only the bundled marketplace copy helper
- skips unrelated Fast Mode, locale, browser-use, plugin UI, Goal, and Computer Use gate patches

This gives the restart-time bundled marketplace failure a smaller and safer remediation path than the full repatch workflow.

### 2. Patch the Desktop bundled plugin copy helper with a Windows fallback

The ASAR patch keeps the existing behavior first:

```js
await fs.cp(source, target, { recursive: true, verbatimSymlinks: true })
```

If that fails on Windows, the patched helper logs:

```text
codex_windows_bundled_marketplace_copy_fallback
```

and falls back to a recursive byte-stream copy using `readFile` / `writeFile` plus directory creation. Non-Windows platforms still throw the original error.

The fallback is intentionally scoped to this bundled marketplace copy helper. It does not broaden permissions, does not modify `WindowsApps` in place, and does not require Codex Desktop to run elevated.

### 3. Avoid UTF-8 path decoding issues when locating the ASAR target

The bundled marketplace patch target is located by enumerating `.vite\build\*.js` directly instead of consuming paths from `rg` stdout. This avoids Windows PowerShell 5 path mojibake when the user profile path contains non-ASCII characters.

### 4. Harden package copy for WindowsApps package layouts

`Copy-PackageLayout` now keeps `robocopy` as the first path, but falls back to a data-only stream copy if:

- `robocopy` fails, or
- the copied package layout is missing `app\resources\app.asar`

This keeps the existing fast path but handles WindowsApps/AppX-protected package files more reliably.

### 5. Fix local bundled plugin repair drift

`install-computer-use-local.ps1` is hardened so local repair can restore the complete bundled plugin state after a Desktop reinstall or partial cache loss:

- uses data-only copies for package/runtime/plugin cache sync instead of relying on `robocopy`
- enables `browser@openai-bundled` and `chrome@openai-bundled` in config in addition to `computer-use@openai-bundled`
- validates those plugin config entries
- can use the installed package's bundled CUA `@oai/sky` runtime when `%LOCALAPPDATA%\OpenAI\Codex\runtimes\cua_node` is absent
- creates/updates the Chrome native messaging manifest and HKCU registry entry when missing
- reads JSON manifests with UTF-8 to avoid non-ASCII path issues
- tolerates newer Computer Use client scripts when the old import anchor is absent

### 6. Trust local MSIX signing cert in Root stores

The patcher now imports the generated signing certificate into Root trust stores as well as TrustedPeople:

- `CurrentUser\Root`
- `CurrentUser\TrustedPeople`
- `LocalMachine\Root` when running elevated
- `LocalMachine\TrustedPeople` when running elevated

This addresses `Add-AppxPackage` failures such as `0x800B0109` where the package is signed but the signing chain does not terminate in a trusted root.

## Usage

For the specific restart-time bundled marketplace sync failure:

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\patch_codex_fast_mode_windows_msix.ps1" -OnlyBundledMarketplaceCopy -DryRun -OutputRoot "<large-local-build-root>"

powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\patch_codex_fast_mode_windows_msix.ps1" -OnlyBundledMarketplaceCopy -Install -Launch -InstallPrerequisites -OutputRoot "<large-local-build-root>"
```

After installing the patched package, run local repair if the user cache is already partially damaged:

```powershell
powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\install-computer-use-local.ps1" -VerifyOnly
powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\install-computer-use-local.ps1" -StrictVerifyOnly
```

## Validation

Validated locally on Windows with an installed `OpenAI.Codex` MSIX package:

- Parsed `patch_codex_fast_mode_windows_msix.ps1` and `install-computer-use-local.ps1` with PowerShell's parser
- Ran `git diff --check`
- Ran:

```powershell
patch_codex_fast_mode_windows_msix.ps1 -OnlyBundledMarketplaceCopy -DryRun -ForceRebuild -OutputRoot D:\codex-pr-dryrun -CleanupAfter
```

- Dry-run found the expected main-process target:

```text
bundled marketplace copy patch target: ...\.vite\build\main-xo3WOnCM.js
bundled marketplace copy patch result: already-patched
```

- Verified local bundled plugin repair after install:

```text
client import ok
helper transport ok
verification ok
```

- Verified bundled plugin state:

```text
computer-use@openai-bundled  installed, enabled
browser@openai-bundled       installed, enabled
chrome@openai-bundled        installed, enabled
```

## Risk / Scope

- The new ASAR patch mode is opt-in via `-OnlyBundledMarketplaceCopy`.
- The fallback only applies to Windows after the original `fs.cp()` path fails.
- The full existing repatch workflow also applies this bundled marketplace patch, but the new mode avoids unrelated gate patches when the evidence points only to marketplace sync failure.
- No files are modified in `C:\Program Files\WindowsApps` in place; package changes still go through the existing MSIX repack/sign/install flow.
- The signing certificate Root trust change is required for locally signed MSIX installation. Machine-level Root import still only happens when the script is run elevated.