### PR TITLE
[codex] Repair stale Desktop thread model state

### DIFF
--- a/README.en.md
+++ b/README.en.md
@@ -19,6 +19,7 @@ Use this skill when Windows Codex Desktop updates cause issues like these:
 - Repair Goal entries, settings entries, or feature buttons that disappear or become disabled after updates.
 - Repair Desktop new-chat/thread-start failures caused by `dynamicTools` schema drift, including `missing field inputSchema` when the CLI smoke path still works.
 - Restore local conversations in the official sidebar after switching `model_provider` / API config when the local history data still exists; if a restored conversation is visible but cannot continue because its working directory is missing, recreate the missing empty directory from the rollout `cwd`.
+- Repair a specifically identified old conversation whose local `model` / `reasoning_effort` remains stale while Desktop already displays or requests a new model. This tool does not repair server-side model stream disconnects.
 - Repair broken local plugin marketplace config or `codex plugin list` errors.
 - Optionally back up and restore local Codex config, skills, marketplaces, and related state.
 - Automatically update this skill to the latest version before each repair attempt.
@@ -44,6 +45,7 @@ Do not run it on macOS. A macOS version needs a separate workflow for the Codex 
 - `scripts/build-remote-control-native-replacement.ps1`: Builds the patched native `app\resources\codex.exe` replacement under a caller-selected work root when the native app-server rejects API-key main auth; use `-CodexSourceRef` and `-AppServerVersion` to build a replacement whose app-server version matches the original native binary when the phone reports a version-expired state.
 - `scripts/install-computer-use-local.ps1`: Windows Computer Use local compatibility reference implementation.
 - `scripts/sync-codex-provider-history.ps1`: Sync local conversation provider metadata so conversations hidden after a `model_provider` switch reappear in the official list; `-RepairMissingCwdDirs` can also repair restored conversations that cannot continue because the recorded `cwd` directory is missing. It does not modify `config.toml` or workspace/project roots by default.
+- `scripts/sync-codex-thread-model.ps1`: Synchronize local `model` and `reasoning_effort` state for explicitly selected active user threads. It previews by default; `-Apply` is required to write SQLite and the matching rollout after creating timestamped backups.
 - `scripts/install-model-instructions-file.ps1`: Optional installer for the bundled `model_instructions_file` prompt asset.
 - `scripts/manage-codex-backups.ps1`: Backup manager for local Codex config, MCP, skills, and marketplaces.
 - `scripts/update-skill-from-github.ps1`: Best-effort self-update script that syncs the latest GitHub version before use.

--- a/README.md
+++ b/README.md
@@ -19,6 +19,7 @@
 - 修复 Goal 入口、部分设置入口、功能按钮在更新后消失或变灰的问题。
 - 修复 Desktop `dynamicTools` schema 漂移导致新建对话 / thread start 报 `missing field inputSchema`，但 CLI smoke 路径仍然可用的问题。
 - 修复切换 `model_provider` / API 配置后，旧会话仍在本地但官方侧边栏不显示的问题；如果恢复后的会话能显示但继续时报“当前工作目录缺失”，可按 rollout 原始 `cwd` 创建缺失空目录。
+- 修复指定旧会话的本地 `model` / `reasoning_effort` 仍停留在旧值、而 Desktop 已显示或请求新模型的线程状态漂移；此工具不修复模型服务端断流。
 - 修复本地插件市场配置损坏、`codex plugin list` 报错的问题。
 - 可选备份和恢复本机 Codex 配置、技能、插件市场等关键状态。
 - 支持每次开始修复前自动将skills更新到最新版本
@@ -45,6 +46,7 @@
 - `scripts/build-remote-control-native-replacement.ps1`：当 native app-server 因 API-key 主认证拒绝手机远控时，在指定工作目录下构建 patched `app\resources\codex.exe` replacement；如果手机提示版本过期，可用 `-CodexSourceRef` 和 `-AppServerVersion` 构建匹配原生 app-server 版本的 replacement。
 - `scripts/install-computer-use-local.ps1`：Windows Computer Use 本地兼容文件安装和校验参考实现。
 - `scripts/sync-codex-provider-history.ps1`：同步本地会话 provider 元数据，让切换 `model_provider` 后消失的会话重新出现在官方列表中；也可用 `-RepairMissingCwdDirs` 修复恢复后会话无法继续的缺失 `cwd` 目录。默认不改 `config.toml`，也不改 workspace/project roots。
+- `scripts/sync-codex-thread-model.ps1`：针对明确指定的非归档 user 线程，同步本地 `model` 和 `reasoning_effort` 状态。默认只预览；必须传入 `-Apply` 才会写入 SQLite 与对应 rollout，并在写入前创建时间戳备份。
 - `scripts/install-model-instructions-file.ps1`：可选安装内置 `model_instructions_file` 提示词资源。
 - `scripts/manage-codex-backups.ps1`：本地 Codex 配置、MCP、skills 和 marketplaces 的备份管理脚本。
 - `scripts/update-skill-from-github.ps1`：使用前尽力同步 GitHub 最新版本的自更新脚本。

--- a/SKILL.md
+++ b/SKILL.md
@@ -1,11 +1,11 @@
 ---
 name: codex-windows-fast-patch
-description: Reapply and repair Windows Codex Desktop after Store upgrades, including Fast Mode request/UI gates, locale i18n, plugin UI gates, Chrome/browser_use gates, Goal command gates, Windows Computer Use availability gates and plugin/runtime repair, phone remote-control pairing under third-party/API-key main app usage, Desktop dynamicTools/inputSchema thread-start schema drift, local conversation visibility recovery after model_provider switches, restored-conversation missing-cwd continuation repair, ASAR integrity repair, signing/installing patched MSIX packages, SDK cleanup, Fast Mode wire verification, local plugin marketplace registration, and optional custom model_instructions_file setup.
+description: Reapply and repair Windows Codex Desktop after Store upgrades, including Fast Mode request/UI gates, locale i18n, plugin UI gates, Chrome/browser_use gates, Goal command gates, Windows Computer Use availability gates and plugin/runtime repair, phone remote-control pairing under third-party/API-key main app usage, Desktop dynamicTools/inputSchema thread-start schema drift, local conversation visibility recovery after model_provider switches, stale per-thread model/reasoning state repair, restored-conversation missing-cwd continuation repair, ASAR integrity repair, signing/installing patched MSIX packages, SDK cleanup, Fast Mode wire verification, local plugin marketplace registration, and optional custom model_instructions_file setup.
 ---
 
 # Codex Windows Fast Patch
 
-Use this skill when the user says Codex Desktop was upgraded and the Fast Mode / Plugins / Goal patch disappeared, asks to repatch Codex on Windows, asks to verify whether Fast Mode is really being sent, asks to restore/register the local plugin marketplace, asks to enable Chrome browser use or Windows Computer Use in Codex Desktop, or asks to enable/repair phone remote control while keeping third-party/API-key model access. Also use it when the language/locale setting reverts after restart, browser or plugin entries are hidden by availability gates, the Computer Control settings page shows "Any App" / "任意应用" as disabled by organization or unavailable in the current region, a Computer Use task reports native pipe, bundled plugin cache, helper path, package import, or runtime initialization errors, phone remote-control QR pairing spins/fails, post-pairing phone-created turns hit the wrong model API endpoint, Desktop new-chat/thread start fails with `missing field inputSchema`, local conversations disappear after switching `model_provider` / API account, restored conversations are visible but cannot continue because the current working directory is missing, or the user explicitly asks to configure the bundled custom `model_instructions_file` prompt asset.
+Use this skill when the user says Codex Desktop was upgraded and the Fast Mode / Plugins / Goal patch disappeared, asks to repatch Codex on Windows, asks to verify whether Fast Mode is really being sent, asks to restore/register the local plugin marketplace, asks to enable Chrome browser use or Windows Computer Use in Codex Desktop, or asks to enable/repair phone remote control while keeping third-party/API-key model access. Also use it when the language/locale setting reverts after restart, browser or plugin entries are hidden by availability gates, the Computer Control settings page shows "Any App" / "任意应用" as disabled by organization or unavailable in the current region, a Computer Use task reports native pipe, bundled plugin cache, helper path, package import, or runtime initialization errors, phone remote-control QR pairing spins/fails, post-pairing phone-created turns hit the wrong model API endpoint, Desktop new-chat/thread start fails with `missing field inputSchema`, local conversations disappear after switching `model_provider` / API account, a specific old conversation retains stale local `model` / `reasoning_effort` state, restored conversations are visible but cannot continue because the current working directory is missing, or the user explicitly asks to configure the bundled custom `model_instructions_file` prompt asset.
 
 ## Platform Compatibility
 
@@ -54,6 +54,7 @@ Before choosing the full MSIX repack path, identify whether the current failure 
 - Use the Phone Remote Control workflow when the user needs mobile pairing/control, the Connections page hides the phone setup card, the QR dialog spins, remote-control setup jumps to ChatGPT auth, the Allow dialog fails, the phone says the Codex environment version expired, or phone-created turns reach Desktop but send model requests to the wrong API endpoint.
 - Use the Missing inputSchema decision workflow when Codex Desktop cannot create a new conversation or local task and the newest Desktop log reports `method=thread/start` with the phrase `missing field inputSchema`. Do not assume this is always MCP. First compare CLI/app-server smoke tests against Desktop logs and inspect whether Desktop is sending non-null app dynamic tools. If the failure follows a suspect MCP server, isolate MCP. If CLI thread start succeeds while Desktop UI fails and extracted ASAR has `webview\assets\app-server-dynamic-tools-*.js` returning a namespace-wrapped `dynamicTools` object, use the Dynamic Tools Schema workflow. Do not run Phone Remote Control or Computer Use repair for this symptom unless separate evidence points there.
 - Use the Provider History Sync workflow when old conversations disappear from the official Desktop sidebar after the user changes `model_provider`, API account, or provider config, but local `sessions`, `archived_sessions`, or `state_5.sqlite` data still exists. Also use it when the conversations reappear but opening/continuing one fails with `当前工作目录缺失`, `current working directory missing`, or `invalid codex request` caused by a missing historical `cwd`. This workflow is data-layer repair; it does not require third-party recovery tools, does not patch ASAR, and must not modify `config.toml`.
+- Use the Thread Model Sync workflow only after evidence identifies one or more thread IDs whose local `model` or `reasoning_effort` is stale. It is a narrow state repair, not a fix for a model provider, a model itself, or a streaming transport failure.
 - Use the targeted bundled marketplace repair when the newest Desktop logs show the runtime marketplace reconciling only 4 bundled plugins instead of the expected `sites,browser,chrome,computer-use,latex`, or show `not_in_bundled_marketplace_plugin_names` uninstalling `sites@openai-bundled`, `browser@openai-bundled`, or `chrome@openai-bundled`. In newer Windows builds, `sites` can be present in the shipped marketplace but filtered out by `features.sites = false`; this should not trigger a broad repatch or Phone Remote Control workflow.
 - If the user asks for Phone Remote Control and ordinary Desktop features in the same repair, patch Phone Remote Control first, then verify Fast Mode/browser/Chrome/Computer Use. If the remote-control MSIX install disturbs Computer Use or Chrome native-host state, immediately run the Computer Use Only workflow and re-run `-StrictVerifyOnly`.
 - Do not infer that a new `resources\codex.exe` PE file means `app.asar` is gone or that Computer Use needs binary patching. Inspect the current package resources first. If `app.asar` still exists and the symptom is a plugin/runtime import or cache failure, run `scripts\install-computer-use-local.ps1` before considering MSIX or binary changes.
@@ -308,6 +309,33 @@ Success criteria:
 - Codex Desktop's official sidebar shows the recovered historical conversations after restart.
 - If the symptom was a visible restored conversation that could not continue, `missing rollout cwd dirs after` reports zero or only reviewed/skipped paths, and the affected conversation can send a new turn after Desktop restart.
 - The Projects/workspace area does not gain new empty project groups as a side effect.
+
+## Thread Model Sync
+
+Use this only when direct local evidence identifies a stale thread record: for example, the saved thread row still has an old `model` / `reasoning_effort` while Desktop or the rollout already shows the intended values. It is not a treatment for `stream disconnected before completion`, an upstream model outage, or a provider-wide model-selection failure.
+
+The script requires explicit thread IDs and previews by default. It selects only rows that are non-archived `thread_source='user'` records with the requested `model_provider` and expected old `model`. An optional `-ExpectedReasoningEffort` adds one more selection guard. It updates only the matching SQLite rows and each selected rollout's first `session_meta` line; it does not recursively rewrite arbitrary JSONL fields.
+
+Run the built-in offline fixture check before relying on a new copy of the script:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\sync-codex-thread-model.ps1" -SelfTest
+```
+
+Preview one affected thread without writing:
+
+```powershell
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\sync-codex-thread-model.ps1" -ThreadId '<thread-id>' -FromModel 'gpt-5.4' -ToModel 'gpt-5.6-terra' -ModelProvider 'krill' -ExpectedReasoningEffort 'medium' -ToReasoningEffort 'xhigh'
+```
+
+Only after reviewing the selected thread IDs and stopping Desktop from an external PowerShell, add `-Apply`:
+
+```powershell
+Get-Process Codex -ErrorAction SilentlyContinue | Where-Object { $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\Codex.exe' } | Stop-Process -Force
+powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\sync-codex-thread-model.ps1" -ThreadId '<thread-id>' -FromModel 'gpt-5.4' -ToModel 'gpt-5.6-terra' -ModelProvider 'krill' -ExpectedReasoningEffort 'medium' -ToReasoningEffort 'xhigh' -Apply
+```
+
+The write path refuses to run while any `Codex` process is active and makes timestamped SQLite and rollout backups under `$env:USERPROFILE\.codex\backups\thread-model-sync`. Stop Codex from an external PowerShell with `Get-Process Codex -ErrorAction SilentlyContinue | Stop-Process -Force`; if no row matches the full scope, the script makes no write. Do not broaden this script into a provider-wide or all-thread migration; use the provider history workflow for provider metadata repair.
 
 ## Important Guardrails
 

--- a/scripts/sync-codex-thread-model.ps1
+++ b/scripts/sync-codex-thread-model.ps1
@@ -1,0 +1,289 @@
+[CmdletBinding(DefaultParameterSetName = 'Repair')]
+param(
+  [string]$CodexHome = (Join-Path $env:USERPROFILE '.codex'),
+  [Parameter(Mandatory, ParameterSetName = 'Repair')]
+  [string[]]$ThreadId,
+  [string]$FromModel = 'gpt-5.4',
+  [string]$ToModel = 'gpt-5.6-terra',
+  [string]$ModelProvider = 'krill',
+  [string]$ExpectedReasoningEffort,
+  [string]$ToReasoningEffort = 'xhigh',
+  [switch]$Apply,
+  [switch]$DryRun,
+  [Parameter(Mandatory, ParameterSetName = 'SelfTest')]
+  [switch]$SelfTest
+)
+
+$ErrorActionPreference = 'Stop'
+$LogPrefix = '[codex-thread-model-sync]'
+
+function Write-Log([string]$Message) {
+  Write-Host "$LogPrefix $Message"
+}
+
+if ($Apply -and $DryRun) {
+  throw 'Use either -Apply or -DryRun, not both.'
+}
+
+if ($Apply) {
+  $runningDesktop = Get-Process Codex -ErrorAction SilentlyContinue
+  if ($runningDesktop) {
+    throw 'Stop all Codex processes from an external PowerShell before using -Apply.'
+  }
+}
+
+$python = Get-Command python -ErrorAction SilentlyContinue | Select-Object -First 1
+if (-not $python) {
+  throw "$LogPrefix python not found"
+}
+
+$script = @'
+import argparse
+import hashlib
+import json
+import os
+import shutil
+import sqlite3
+import tempfile
+from datetime import datetime
+from pathlib import Path
+
+
+def compact_json(value):
+    return json.dumps(value, ensure_ascii=False, separators=(",", ":"))
+
+
+def normalize_rollout_path(value):
+    text = value or ""
+    if text.startswith("\\\\?\\"):
+        text = text[4:]
+    return Path(text)
+
+
+def find_state_db(codex_home):
+    for candidate in (codex_home / "sqlite" / "state_5.sqlite", codex_home / "state_5.sqlite"):
+        if candidate.exists():
+            return candidate
+    raise SystemExit(f"state db not found under {codex_home}")
+
+
+def required_columns(conn):
+    columns = {row[1] for row in conn.execute("pragma table_info(threads)")}
+    needed = {"id", "archived", "thread_source", "model_provider", "model", "reasoning_effort", "rollout_path"}
+    missing = sorted(needed - columns)
+    if missing:
+        raise SystemExit(f"threads table is missing required columns: {', '.join(missing)}")
+
+
+def select_threads(conn, args):
+    placeholders = ",".join("?" for _ in args.thread_id)
+    sql = f"""
+        select id, rollout_path, model, reasoning_effort
+        from threads
+        where id in ({placeholders})
+          and archived = 0
+          and thread_source = 'user'
+          and model_provider = ?
+          and model = ?
+    """
+    values = [*args.thread_id, args.model_provider, args.from_model]
+    if args.expected_reasoning_effort is not None:
+        sql += " and reasoning_effort = ?"
+        values.append(args.expected_reasoning_effort)
+    return [dict(row) for row in conn.execute(sql, values).fetchall()]
+
+
+def rewrite_session_meta(path, thread_id, to_model, to_reasoning_effort):
+    original = path.read_text(encoding="utf-8")
+    first, separator, rest = original.partition("\n")
+    if not separator:
+        raise ValueError("rollout does not contain a session_meta line")
+    meta = json.loads(first.rstrip("\r"))
+    payload = meta.get("payload") if isinstance(meta, dict) else None
+    if meta.get("type") != "session_meta" or not isinstance(payload, dict):
+        raise ValueError("rollout first line is not session_meta")
+    if payload.get("id") != thread_id:
+        raise ValueError("rollout session_meta id does not match selected thread")
+    changed = payload.get("model") != to_model or payload.get("reasoning_effort") != to_reasoning_effort
+    payload["model"] = to_model
+    payload["reasoning_effort"] = to_reasoning_effort
+    return compact_json(meta) + "\n" + rest, changed
+
+
+def backup_file(path, backup_dir):
+    backup_dir.mkdir(parents=True, exist_ok=True)
+    fingerprint = hashlib.sha256(str(path).encode("utf-8")).hexdigest()[:12]
+    target = backup_dir / f"{path.name}.{fingerprint}.bak"
+    shutil.copy2(path, target)
+    return str(target)
+
+
+def backup_sqlite(source, backup_path):
+    source_conn = sqlite3.connect(source)
+    backup_conn = sqlite3.connect(backup_path)
+    try:
+        source_conn.backup(backup_conn)
+    finally:
+        backup_conn.close()
+        source_conn.close()
+
+
+def atomic_write(path, content):
+    temporary = path.with_name(path.name + f".thread-model-sync.{os.getpid()}.tmp")
+    temporary.write_text(content, encoding="utf-8", newline="")
+    os.replace(temporary, path)
+
+
+def self_test():
+    with tempfile.TemporaryDirectory() as directory:
+        root = Path(directory)
+        db = root / "state_5.sqlite"
+        rollout = root / "rollout.jsonl"
+        rollout.write_text(
+            '{"type":"session_meta","payload":{"id":"keep","model":"gpt-5.4","reasoning_effort":"medium"}}\n'
+            '{"type":"event_msg","payload":{"model":"gpt-5.4"}}\n',
+            encoding="utf-8",
+        )
+        conn = sqlite3.connect(db)
+        conn.execute("create table threads (id text, archived integer, thread_source text, model_provider text, model text, reasoning_effort text, rollout_path text)")
+        conn.executemany(
+            "insert into threads values (?, ?, ?, ?, ?, ?, ?)",
+            [
+                ("keep", 0, "user", "krill", "gpt-5.4", "medium", str(rollout)),
+                ("archived", 1, "user", "krill", "gpt-5.4", "medium", str(rollout)),
+                ("assistant", 0, "assistant", "krill", "gpt-5.4", "medium", str(rollout)),
+            ],
+        )
+        conn.row_factory = sqlite3.Row
+        args = argparse.Namespace(thread_id=["keep", "archived", "assistant"], model_provider="krill", from_model="gpt-5.4", expected_reasoning_effort="medium")
+        assert [row["id"] for row in select_threads(conn, args)] == ["keep"]
+        rewritten, changed = rewrite_session_meta(rollout, "keep", "gpt-5.6-terra", "xhigh")
+        assert changed
+        assert '"model":"gpt-5.6-terra"' in rewritten.splitlines()[0]
+        assert rewritten.splitlines()[1] == '{"type":"event_msg","payload":{"model":"gpt-5.4"}}'
+        conn.close()
+    print(compact_json({"self_test": "passed"}))
+
+
+def main():
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--codex-home")
+    parser.add_argument("--thread-id", action="append")
+    parser.add_argument("--from-model")
+    parser.add_argument("--to-model")
+    parser.add_argument("--model-provider")
+    parser.add_argument("--expected-reasoning-effort")
+    parser.add_argument("--to-reasoning-effort")
+    parser.add_argument("--apply", action="store_true")
+    parser.add_argument("--self-test", action="store_true")
+    args = parser.parse_args()
+    if args.self_test:
+        self_test()
+        return
+
+    codex_home = Path(args.codex_home).expanduser()
+    db_path = find_state_db(codex_home)
+    conn = sqlite3.connect(db_path)
+    conn.row_factory = sqlite3.Row
+    required_columns(conn)
+    selected = select_threads(conn, args)
+    rewritten_rollouts = []
+    for row in selected:
+        if not row["rollout_path"]:
+            raise SystemExit(f"selected thread has no rollout path: {row['id']}")
+        path = normalize_rollout_path(row["rollout_path"])
+        if not path.exists():
+            raise SystemExit(f"selected thread rollout does not exist: {row['id']}")
+        content, changed = rewrite_session_meta(path, row["id"], args.to_model, args.to_reasoning_effort)
+        if changed:
+            rewritten_rollouts.append((path, content))
+
+    report = {
+        "db_path": str(db_path),
+        "thread_ids_requested": args.thread_id,
+        "selected_count": len(selected),
+        "selected_thread_ids": [row["id"] for row in selected],
+        "from_model": args.from_model,
+        "to_model": args.to_model,
+        "model_provider": args.model_provider,
+        "expected_reasoning_effort": args.expected_reasoning_effort,
+        "to_reasoning_effort": args.to_reasoning_effort,
+        "planned_rollout_updates": len(rewritten_rollouts),
+        "apply": args.apply,
+        "sqlite_backup": None,
+        "rollout_backups": [],
+        "sqlite_updated_rows": 0,
+        "rollout_updated_files": 0,
+    }
+    if not args.apply or not selected:
+        print(compact_json(report))
+        return
+
+    stamp = datetime.now().strftime("%Y%m%d-%H%M%S-%f")
+    backup_root = codex_home / "backups" / "thread-model-sync" / stamp
+    sqlite_backup = backup_root / "state_5.sqlite.bak"
+    backup_sqlite(db_path, sqlite_backup)
+    report["sqlite_backup"] = str(sqlite_backup)
+    for path, content in rewritten_rollouts:
+        report["rollout_backups"].append(backup_file(path, backup_root / "rollouts"))
+        atomic_write(path, content)
+    report["rollout_updated_files"] = len(rewritten_rollouts)
+
+    thread_ids = [row["id"] for row in selected]
+    placeholders = ",".join("?" for _ in thread_ids)
+    conn.execute("begin immediate")
+    try:
+        updated = conn.execute(
+            f"update threads set model = ?, reasoning_effort = ? where id in ({placeholders})",
+            [args.to_model, args.to_reasoning_effort, *thread_ids],
+        ).rowcount
+        if updated != len(thread_ids):
+            raise RuntimeError(f"expected to update {len(thread_ids)} rows, updated {updated}")
+        conn.commit()
+    except Exception:
+        conn.rollback()
+        raise
+    finally:
+        conn.close()
+    report["sqlite_updated_rows"] = updated
+    print(compact_json(report))
+
+
+if __name__ == "__main__":
+    main()
+'@
+
+$temp = Join-Path $env:TEMP ('codex-thread-model-sync-' + [guid]::NewGuid().ToString('N') + '.py')
+try {
+  Set-Content -LiteralPath $temp -Value $script -Encoding UTF8
+  if ($SelfTest) {
+    & $python.Source $temp '--self-test'
+  } else {
+    $args = @(
+      $temp,
+      '--codex-home', $CodexHome,
+      '--from-model', $FromModel,
+      '--to-model', $ToModel,
+      '--model-provider', $ModelProvider,
+      '--to-reasoning-effort', $ToReasoningEffort
+    )
+    foreach ($id in $ThreadId) {
+      if ([string]::IsNullOrWhiteSpace($id)) {
+        throw 'ThreadId cannot contain an empty value.'
+      }
+      $args += @('--thread-id', $id)
+    }
+    if ($PSBoundParameters.ContainsKey('ExpectedReasoningEffort')) {
+      $args += @('--expected-reasoning-effort', $ExpectedReasoningEffort)
+    }
+    if ($Apply) {
+      $args += '--apply'
+    }
+    & $python.Source @args
+  }
+  if ($LASTEXITCODE -ne 0) {
+    throw "$LogPrefix helper failed with exit code $LASTEXITCODE"
+  }
+} finally {
+  Remove-Item -LiteralPath $temp -Force -ErrorAction SilentlyContinue
+}


### PR DESCRIPTION
## Summary

- add a narrowly scoped `sync-codex-thread-model.ps1` repair for explicitly identified Desktop threads whose persisted `model` / `reasoning_effort` state is stale
- require one or more thread IDs and preview by default; writing requires `-Apply`
- update only non-archived user-thread SQLite rows and the matching rollout `session_meta`, with timestamped SQLite and rollout backups
- refuse `-Apply` while Codex is running, and document the distinction between provider-history recovery, stale per-thread state, and upstream streaming failures

## Problem

After a Desktop update or a UI model switch, an old thread can retain stale local `model` / `reasoning_effort` state even though Desktop UI or rollout metadata already shows the intended model. This can leave persisted thread state split from the effective session state.

This is not a fix for a model provider, a model itself, or errors such as `stream disconnected before completion`.

## Scope and safeguards

- requires explicit thread IDs
- restricts matches to active `thread_source='user'` rows under the specified provider and expected old model
- supports an optional expected reasoning-effort guard
- previews by default; `-Apply` is required for writes
- updates only SQLite thread state plus the rollout first-line `session_meta`
- refuses a partial repair when a selected thread lacks a usable rollout
- does not modify `config.toml`, workspace roots, or arbitrary JSONL event fields

## Validation

- `sync-codex-thread-model.ps1 -SelfTest`
- PowerShell parse check for all `scripts/*.ps1`
- `git diff --check`
- dry-run against a previously repaired thread returned `selected_count: 0` without writing Desktop state
- `-Apply` was verified to refuse while Codex is running