### PR TITLE
Merge Windows 12708 repair hardening

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -280,14 +280,14 @@ Read the dry-run output before selecting the write path:
 Provider sync write path:
 
 ```powershell
-Get-Process Codex -ErrorAction SilentlyContinue | Where-Object { $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\Codex.exe' } | Stop-Process -Force
+Get-Process Codex,ChatGPT -ErrorAction SilentlyContinue | Where-Object { $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\Codex.exe' -or $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\ChatGPT.exe' } | Stop-Process -Force
 powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\sync-codex-provider-history.ps1"
 ```
 
 Missing cwd repair path:
 
 ```powershell
-Get-Process Codex -ErrorAction SilentlyContinue | Where-Object { $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\Codex.exe' } | Stop-Process -Force
+Get-Process Codex,ChatGPT -ErrorAction SilentlyContinue | Where-Object { $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\Codex.exe' -or $_.Path -like 'C:\Program Files\WindowsApps\OpenAI.Codex_*\app\ChatGPT.exe' } | Stop-Process -Force
 powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\skills\codex-windows-fast-patch\scripts\sync-codex-provider-history.ps1" -RepairMissingCwdDirs
 ```
 
@@ -320,12 +320,14 @@ Success criteria:
 - Do not modify `C:\Program Files\WindowsApps` in place. Use the MSIX repack script.
 - Do not run the phone remote-control MSIX patch as a default repatch side effect. Use it only for phone remote-control tasks or when the user explicitly asks for that workflow.
 - Do not treat every `missing field inputSchema` as an MCP problem. If CLI smoke tests pass while Desktop UI fails and the dynamic-tools ASAR asset still returns a namespace wrapper, use the Dynamic Tools Schema workflow instead of disabling unrelated MCP servers.
-- Do not trust a response like `FAST_CHECK_OK` as proof of Fast Mode. Trust only the wrapper/script wire verification, which captures Codex's local `/v1/responses` HTTP body or WebSocket frame and checks `service_tier=priority`.
+- Do not trust a response like `FAST_CHECK_OK` as proof of Fast Mode. Trust only the wrapper/script wire verification, which runs with an isolated temporary `CODEX_HOME`, serves the CLI's `/v1/models` probe, then captures a `/v1/responses` HTTP body or WebSocket frame and checks `service_tier=priority`. A models-only request is not proof.
 - If the app launches then immediately exits, run Electron logging and check for ASAR integrity failures:
 
 ```powershell
 $pkg = Get-AppxPackage -Name OpenAI.Codex | Select-Object -First 1
-$exe = Join-Path $pkg.InstallLocation 'app\Codex.exe'
+$manifest = [xml](Get-Content -Raw -LiteralPath (Join-Path $pkg.InstallLocation 'AppxManifest.xml'))
+$desktopExecutable = [string](($manifest.Package.Applications.Application | Select-Object -First 1).Executable)
+$exe = Join-Path $pkg.InstallLocation $desktopExecutable
 $env:ELECTRON_ENABLE_LOGGING='1'
 Push-Location (Split-Path -Parent $exe)
 & $exe --enable-logging=stderr --v=1 2>&1 | Select-String -Pattern 'FATAL|Integrity|asar|ERROR'
@@ -438,7 +440,7 @@ After configuring `model_instructions_file`, restart Codex CLI/Desktop or start 
 
 ## Computer Use Only
 
-Use this path for local Computer Use plugin/runtime repair without repacking the MSIX. It rebuilds the local `openai-bundled` marketplace mirror, repairs stable `computer-use` / `browser` / `chrome` cache links, overlays the installed CUA `@oai/sky` runtime into the local Computer Use plugin, patches the Computer Use client import shape when needed, removes stale `SKY_CUA_NATIVE_PIPE` overrides from `config.toml`, updates the Chrome native messaging host to stable cache paths, and verifies both the client import and helper transport.
+Use this path for local Computer Use plugin/runtime repair without repacking the MSIX. It rebuilds the local `openai-bundled` marketplace mirror, repairs stable `computer-use` / `browser` / `chrome` / `sites` cache links from one pinned installed-package source, overlays the installed CUA `@oai/sky` runtime into the local Computer Use plugin, patches localized/default-value Chrome registry parsing and the Computer Use client import shape when needed, preserves a live `SKY_CUA_NATIVE_PIPE` configuration while removing stale overrides, updates the Chrome native messaging host to stable cache paths, and verifies both the client import and helper transport.
 
 To refresh only the local Windows Computer Use files and environment gate:
 
@@ -480,8 +482,8 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\ski
 - If an existing `config.toml` was modified, the log shows a timestamped backup under `.codex\backups\config\`.
 - `Get-AppxPackage -Name OpenAI.Codex` shows `SignatureKind = Developer`.
 - The install log launches the patched Desktop package through its AppUserModelId, avoiding direct-executable access failures under `WindowsApps`.
-- Codex Desktop processes stay alive from `...\WindowsApps\OpenAI.Codex_<version>...\app\Codex.exe`.
-- Fast Mode verification logs `request wire service_tier=priority`.
+- The manifest-declared Codex Desktop process stays alive from the installed package, currently `...\app\ChatGPT.exe` on newer builds and `...\app\Codex.exe` on older builds.
+- Fast Mode verification reaches `/v1/responses` and logs `request wire service_tier=priority`; `/v1/models` probes alone do not pass verification.
 - The patch log includes `fast-mode UI patch result` and `locale i18n patch result`, each either `patched` or `already-patched`.
 - The patch log includes `custom models patch result`, and the patched model filter contains all configured custom model IDs.
 - The patch log includes `browser-use gate patch result`, either `patched` or `already-patched`.

--- a/references/restriction-debug-cases.md
+++ b/references/restriction-debug-cases.md
@@ -14,7 +14,7 @@ Symptoms:
 Checks:
 
 - Capture the actual `/v1/responses` request made by Codex Desktop and verify `service_tier=priority` on the wire.
-- If the bundled verifier reports that it did not find `service_tier`, check whether the current CLI removed `responses_websockets`. Newer CLIs can send the verification request over HTTP, so the capture helper must read the HTTP request body instead of treating an empty WebSocket log as a Fast Mode failure.
+- If the bundled verifier reports that it did not find `service_tier`, check whether the current CLI removed `responses_websockets`. Newer CLIs can probe `/v1/models` before sending the verification request over HTTP, so the capture helper must return a usable model list, read the later `/v1/responses` body, and reject a models-only capture instead of treating it as proof of Fast Mode.
 - If the upstream is CPA or another proxy, inspect the proxy-side override rules. Local capture only proves Codex sent the parameter; the proxy can still drop, rewrite, or ignore it.
 - In newer Codex builds, inspect `webview\assets\read-service-tier-for-request-*.js`. A shape like `return authMethod===\`chatgpt\` ? featureRequirements?.fast_mode !== false : false` means API-key/local requests are still forced out of Fast Mode.
 - Inspect `webview\assets\use-service-tier-settings-*.js` independently; Fast request wiring can be correct while the UI gate remains closed, or the UI can be open while request wiring is still wrong.

--- a/scripts/install-computer-use-local.ps1
+++ b/scripts/install-computer-use-local.ps1
@@ -293,6 +293,69 @@ function Remove-TomlTableKeys {
   Write-Utf8NoBom $ConfigPath $updated
 }
 
+function Get-ChromeUserDataDirectoryOverride {
+  $candidates = @()
+  $userOverride = [Environment]::GetEnvironmentVariable('CODEX_CHROME_USER_DATA_DIR', 'User')
+  if (-not [string]::IsNullOrWhiteSpace($userOverride)) {
+    $candidates += [Environment]::ExpandEnvironmentVariables($userOverride.Trim().Trim('"'))
+  }
+
+  if (-not [string]::IsNullOrWhiteSpace($env:LOCALAPPDATA)) {
+    $candidates += (Join-Path $env:LOCALAPPDATA 'Google\Chrome\User Data')
+  }
+
+  $chromeAppPathKeys = @(
+    'Registry::HKEY_CURRENT_USER\Software\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe',
+    'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe',
+    'Registry::HKEY_LOCAL_MACHINE\SOFTWARE\WOW6432Node\Microsoft\Windows\CurrentVersion\App Paths\chrome.exe'
+  )
+  foreach ($registryPath in $chromeAppPathKeys) {
+    try {
+      $chromeExe = [string](Get-Item -LiteralPath $registryPath -ErrorAction Stop).GetValue('')
+    } catch {
+      continue
+    }
+    if ([string]::IsNullOrWhiteSpace($chromeExe)) {
+      continue
+    }
+
+    $chromeExe = [Environment]::ExpandEnvironmentVariables($chromeExe.Trim().Trim('"'))
+    if (-not (Test-Path -LiteralPath $chromeExe -PathType Leaf)) {
+      continue
+    }
+
+    $appDirectory = Split-Path -Parent $chromeExe
+    if ((Split-Path -Leaf $appDirectory) -ieq 'App') {
+      $candidates += (Join-Path (Split-Path -Parent $appDirectory) 'Data')
+    }
+  }
+
+  $seen = @{}
+  foreach ($candidate in $candidates) {
+    try {
+      $resolved = (Resolve-Path -LiteralPath $candidate -ErrorAction Stop).Path
+    } catch {
+      continue
+    }
+    $key = $resolved.TrimEnd('\').ToLowerInvariant()
+    if ($seen.ContainsKey($key)) {
+      continue
+    }
+    $seen[$key] = $true
+
+    if (-not (Test-Path -LiteralPath (Join-Path $resolved 'Local State') -PathType Leaf)) {
+      continue
+    }
+    foreach ($profile in @(Get-ChildItem -LiteralPath $resolved -Directory -Force -ErrorAction SilentlyContinue)) {
+      if (Test-Path -LiteralPath (Join-Path $profile.FullName 'Preferences') -PathType Leaf) {
+        return $resolved
+      }
+    }
+  }
+
+  return $null
+}
+
 function Enable-UserEnvironment {
   if ($SkipUserEnvironment) {
     Write-Log 'skipping user environment update'
@@ -301,6 +364,14 @@ function Enable-UserEnvironment {
 
   [Environment]::SetEnvironmentVariable('CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE', '1', 'User')
   $env:CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE = '1'
+
+  $chromeUserDataDirectory = Get-ChromeUserDataDirectoryOverride
+  if ($chromeUserDataDirectory) {
+    [Environment]::SetEnvironmentVariable('CODEX_CHROME_USER_DATA_DIR', $chromeUserDataDirectory, 'User')
+    $env:CODEX_CHROME_USER_DATA_DIR = $chromeUserDataDirectory
+  } else {
+    Write-Log 'warning: Chrome user data directory was not detected; CODEX_CHROME_USER_DATA_DIR was not changed'
+  }
 
   try {
     $signature = @'
@@ -321,6 +392,9 @@ public static class CodexEnvBroadcast {
   }
 
   Write-Log 'enabled CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE=1 for this process and the current user'
+  if ($chromeUserDataDirectory) {
+    Write-Log "enabled CODEX_CHROME_USER_DATA_DIR=$chromeUserDataDirectory for this process and the current user"
+  }
 }
 
 function Get-PluginJson {
@@ -776,6 +850,33 @@ function Update-BundledMarketplaceManifest {
   ConvertTo-JsonFile $manifestPath $json
 }
 
+function Get-ComputerUsePipeConfigState {
+  param([string]$ConfigPath)
+
+  if (-not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) {
+    return [pscustomobject]@{ Present = $false; Active = $false; PipePath = '' }
+  }
+
+  $content = [System.IO.File]::ReadAllText($ConfigPath, [System.Text.UTF8Encoding]::new($false))
+  $present = $content -match '(?m)^\s*SKY_CUA_NATIVE_PIPE(?:_DIRECTORY)?\s*='
+  if (-not $present) {
+    return [pscustomobject]@{ Present = $false; Active = $false; PipePath = '' }
+  }
+
+  $enabledMatch = [regex]::Match($content, '(?m)^\s*SKY_CUA_NATIVE_PIPE\s*=\s*["''](?<value>[^"'']+)["'']\s*$')
+  $directoryMatch = [regex]::Match($content, '(?m)^\s*SKY_CUA_NATIVE_PIPE_DIRECTORY\s*=\s*["''](?<value>[^"'']+)["'']\s*$')
+  $pipePath = if ($directoryMatch.Success) { $directoryMatch.Groups['value'].Value } else { '' }
+  $active = (
+    $enabledMatch.Success -and
+    $enabledMatch.Groups['value'].Value -eq '1' -and
+    $directoryMatch.Success -and
+    $pipePath.StartsWith('\\.\pipe\codex-computer-use-', [StringComparison]::OrdinalIgnoreCase) -and
+    (Test-Path -LiteralPath $pipePath)
+  )
+
+  return [pscustomobject]@{ Present = $true; Active = $active; PipePath = $pipePath }
+}
+
 function Update-CodexConfig {
   param([string]$MarketplaceRoot)
 
@@ -803,10 +904,15 @@ function Update-CodexConfig {
   Set-TomlTable $configPath '[windows]' @{
     sandbox = 'unelevated'
   }
-  Remove-TomlTableKeys $configPath '[mcp_servers.node_repl.env]' @(
-    'SKY_CUA_NATIVE_PIPE',
-    'SKY_CUA_NATIVE_PIPE_DIRECTORY'
-  ) 'remove-stale-computer-use-pipe-env'
+  $pipeState = Get-ComputerUsePipeConfigState $configPath
+  if ($pipeState.Present -and $pipeState.Active) {
+    Write-Log "preserving active Computer Use pipe config: $($pipeState.PipePath)"
+  } else {
+    Remove-TomlTableKeys $configPath '[mcp_servers.node_repl.env]' @(
+      'SKY_CUA_NATIVE_PIPE',
+      'SKY_CUA_NATIVE_PIPE_DIRECTORY'
+    ) 'remove-stale-computer-use-pipe-env'
+  }
 }
 
 function Test-TomlSyntax {
@@ -1105,9 +1211,11 @@ function Update-ChromeNativeMessagingManifest {
 }
 
 function Sync-BundledMarketplaceFromInstalledApp {
-  param([string]$MarketplaceRoot)
+  param(
+    [string]$MarketplaceRoot,
+    [string]$SourceRoot
+  )
 
-  $sourceRoot = Get-InstalledBundledMarketplaceRoot
   $parent = Split-Path -Parent $MarketplaceRoot
   Resolve-OrCreateDirectory $parent | Out-Null
   Assert-UnderPath $MarketplaceRoot $parent
@@ -1116,8 +1224,94 @@ function Sync-BundledMarketplaceFromInstalledApp {
     (Join-Path $CodexHome 'plugins\cache\openai-bundled')
   )
 
-  Write-Log "syncing installed openai-bundled marketplace: $sourceRoot -> $MarketplaceRoot"
-  Copy-DirectoryDataOnly $sourceRoot $MarketplaceRoot
+  Write-Log "syncing installed openai-bundled marketplace: $SourceRoot -> $MarketplaceRoot"
+  Copy-DirectoryDataOnly $SourceRoot $MarketplaceRoot
+}
+
+function Test-BrowserClientProcessShimCompatible {
+  param([string]$Content)
+
+  $localProxy = "  const process = processShim;`n  const global = Object.create(globalThis, { process: { value: processShim, enumerable: true } });"
+  if ($Content.Contains($localProxy)) {
+    return $true
+  }
+
+  foreach ($legacyBinding in @(
+    'globalThis.process = processShim;',
+    'globalThis.global.process = processShim;',
+    'const process = processShim;'
+  )) {
+    if ($Content.Contains($legacyBinding)) {
+      return $false
+    }
+  }
+
+  foreach ($directShimMarker in @(
+    'const processShim = {',
+    'processShim.on("beforeExit"',
+    'processShim.memoryUsage().rss',
+    'typeof processShim.versions.icu'
+  )) {
+    if (-not $Content.Contains($directShimMarker)) {
+      return $false
+    }
+  }
+
+  return $true
+}
+
+function Patch-ChromeWindowsRegistryParsing {
+  param([string]$ChromePluginRoot)
+
+  $genericOld = 'if (match && match[1] === label) return stripRegistryString(match[2]);'
+  $genericNew = 'if (match && (valueName == null || match[1] === label)) return stripRegistryString(match[2]);'
+  foreach ($relativePath in @('scripts\open-chrome-window.js', 'scripts\installed-browsers.js')) {
+    $path = Join-Path $ChromePluginRoot $relativePath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+      throw "missing Chrome registry helper: $path"
+    }
+    $content = [System.IO.File]::ReadAllText($path, [System.Text.UTF8Encoding]::new($false))
+    if ($content.Contains($genericNew)) {
+      continue
+    }
+    if (-not $content.Contains($genericOld)) {
+      throw "Chrome registry parser anchor not found: $path"
+    }
+    Write-Utf8NoBom $path ($content.Replace($genericOld, $genericNew))
+  }
+
+  $nativeHostPath = Join-Path $ChromePluginRoot 'scripts\check-native-host-manifest.js'
+  $nativeOld = 'if (match && match[1] === valueName) return stripRegistryString(match[2]);'
+  $nativeNew = 'if (match && (valueName === "(Default)" || match[1] === valueName)) return stripRegistryString(match[2]);'
+  if (-not (Test-Path -LiteralPath $nativeHostPath -PathType Leaf)) {
+    throw "missing Chrome native-host registry helper: $nativeHostPath"
+  }
+  $nativeContent = [System.IO.File]::ReadAllText($nativeHostPath, [System.Text.UTF8Encoding]::new($false))
+  if (-not $nativeContent.Contains($nativeNew)) {
+    if (-not $nativeContent.Contains($nativeOld)) {
+      throw "Chrome native-host registry parser anchor not found: $nativeHostPath"
+    }
+    Write-Utf8NoBom $nativeHostPath ($nativeContent.Replace($nativeOld, $nativeNew))
+  }
+
+  $browserClientPath = Join-Path $ChromePluginRoot 'scripts\browser-client.mjs'
+  if (-not (Test-Path -LiteralPath $browserClientPath -PathType Leaf)) {
+    throw "missing Chrome browser client: $browserClientPath"
+  }
+  $browserClientContent = [System.IO.File]::ReadAllText($browserClientPath, [System.Text.UTF8Encoding]::new($false))
+  $browserClientNew = "  const process = processShim;`n  const global = Object.create(globalThis, { process: { value: processShim, enumerable: true } });"
+  if (-not (Test-BrowserClientProcessShimCompatible $browserClientContent)) {
+    $browserClientOld = "  globalThis.process = processShim;`n  globalThis.global = globalThis.global ?? globalThis;`n  globalThis.global.process = processShim;"
+    $browserClientIntermediate = "  const process = processShim;`n  const global = globalThis;"
+    $browserClientIntermediate2 = "  const process = processShim;`n  const global = Object.assign(Object.create(globalThis), { process: processShim });"
+    $browserClientAnchor = if ($browserClientContent.Contains($browserClientOld)) { $browserClientOld } elseif ($browserClientContent.Contains($browserClientIntermediate)) { $browserClientIntermediate } elseif ($browserClientContent.Contains($browserClientIntermediate2)) { $browserClientIntermediate2 } else { $null }
+    if ($null -eq $browserClientAnchor) {
+      throw "Chrome browser client process shim anchor not found: $browserClientPath"
+    }
+    Write-Utf8NoBom $browserClientPath ($browserClientContent.Replace($browserClientAnchor, $browserClientNew))
+  }
+
+  Write-Log 'patched Chrome registry parsing and browser runtime process shim compatibility'
 }
 
 function Test-BundledMarketplaceMirror {
@@ -1221,7 +1415,8 @@ function Test-CodexConfig {
     if ($content -notmatch '(?ms)^\[windows\]\s*\r?\n(?:(?!^\[).)*sandbox\s*=\s*[''"]unelevated[''"]') {
       throw 'config.toml is missing windows.sandbox=unelevated'
     }
-    if ($content -match '(?m)^\s*SKY_CUA_NATIVE_PIPE(?:_DIRECTORY)?\s*=') {
+    $pipeState = Get-ComputerUsePipeConfigState $ConfigPath
+    if ($pipeState.Present -and -not $pipeState.Active) {
       throw 'config.toml contains stale SKY_CUA_NATIVE_PIPE environment override'
     }
     Write-Log 'warning: python not found; config source path was not semantically validated'
@@ -1274,9 +1469,15 @@ elif windows.get("sandbox") != "unelevated":
 
 node_repl_env = data.get("mcp_servers", {}).get("node_repl", {}).get("env", {})
 if isinstance(node_repl_env, dict):
-    for key in ("SKY_CUA_NATIVE_PIPE", "SKY_CUA_NATIVE_PIPE_DIRECTORY"):
-        if key in node_repl_env:
-            errors.append(f"remove stale mcp_servers.node_repl.env.{key}")
+    pipe_enabled = node_repl_env.get("SKY_CUA_NATIVE_PIPE")
+    pipe_directory = node_repl_env.get("SKY_CUA_NATIVE_PIPE_DIRECTORY")
+    if pipe_enabled is not None or pipe_directory is not None:
+        if str(pipe_enabled) != "1":
+            errors.append("mcp_servers.node_repl.env.SKY_CUA_NATIVE_PIPE must be 1")
+        if not isinstance(pipe_directory, str) or not pipe_directory.startswith(r"\\.\pipe\codex-computer-use-"):
+            errors.append("mcp_servers.node_repl.env.SKY_CUA_NATIVE_PIPE_DIRECTORY is not a Codex Computer Use pipe")
+        elif not pathlib.Path(pipe_directory).exists():
+            errors.append("mcp_servers.node_repl.env.SKY_CUA_NATIVE_PIPE_DIRECTORY is stale")
 
 if errors:
     for error in errors:
@@ -1430,17 +1631,19 @@ function Install-ComputerUse {
   Assert-UnderPath $latestPath $cacheRoot
 
   Remove-StaleChromeNativeHostEntries
-  Sync-BundledMarketplaceFromInstalledApp $marketplaceRoot
+  $installedMarketplaceRoot = Get-InstalledBundledMarketplaceRoot
+  Sync-BundledMarketplaceFromInstalledApp $marketplaceRoot $installedMarketplaceRoot
+  Patch-ChromeWindowsRegistryParsing (Join-Path $marketplaceRoot 'plugins\chrome')
   Write-PluginTree $pluginSourceRoot
   Update-BundledMarketplaceManifest $marketplaceRoot
   Update-CodexConfig $marketplaceRoot
   Enable-UserEnvironment
 
-  $installedMarketplaceRoot = Get-InstalledBundledMarketplaceRoot
   $computerUseCacheRoot = Sync-OpenAiBundledPluginCache $installedMarketplaceRoot 'computer-use'
   Write-PluginTree $computerUseCacheRoot
   $browserCacheRoot = Sync-OpenAiBundledPluginCache $installedMarketplaceRoot 'browser'
   $chromeCacheRoot = Sync-OpenAiBundledPluginCache $installedMarketplaceRoot 'chrome'
+  Patch-ChromeWindowsRegistryParsing $chromeCacheRoot
   if (Test-BundledMarketplacePluginAvailable $installedMarketplaceRoot 'sites') {
     $sitesCacheRoot = Sync-OpenAiBundledPluginCache $installedMarketplaceRoot 'sites'
     Write-Log "installed cached plugin: $sitesCacheRoot"
@@ -1477,6 +1680,9 @@ function Test-ComputerUse {
   }
   $chromeNativeManifest = Join-Path $env:LOCALAPPDATA 'OpenAI\extension\com.openai.codexextension.json'
   $chromeHostPath = Join-Path $chromeCacheVersionRoot 'extension-host\windows\x64\extension-host.exe'
+  $chromeLatestHostPath = Join-Path $chromeCacheLatest 'extension-host\windows\x64\extension-host.exe'
+  $marketplaceBrowserClientPath = Join-Path $chromePluginRoot 'scripts\browser-client.mjs'
+  $cachedBrowserClientPath = Join-Path $chromeCacheVersionRoot 'scripts\browser-client.mjs'
   $computerUseClientPath = Join-Path $cacheLatest 'scripts\computer-use-client.mjs'
   $computerUseBasePath = Join-Path $cacheLatest 'node_modules\@oai\sky\dist\project\cua\sky_js\src\targets\windows\internal\computer_use_client_base.js'
   $helperTransportPath = Join-Path $cacheLatest 'node_modules\@oai\sky\dist\project\cua\sky_js\src\targets\windows\internal\helper_transport.js'
@@ -1491,6 +1697,8 @@ function Test-ComputerUse {
     (Join-Path $browserCacheVersionRoot '.codex-plugin\plugin.json'),
     (Join-Path $chromeCacheVersionRoot '.codex-plugin\plugin.json'),
     $chromeHostPath,
+    $marketplaceBrowserClientPath,
+    $cachedBrowserClientPath,
     (Join-Path $cacheLatest 'node_modules\@oai\sky\package.json'),
     (Join-Path $cacheLatest 'node_modules\@oai\sky\bin\windows\codex-computer-use.exe'),
     $computerUseBasePath,
@@ -1507,6 +1715,29 @@ function Test-ComputerUse {
   foreach ($path in $required) {
     if (-not (Test-Path -LiteralPath $path)) {
       throw "missing required Computer Use path: $path"
+    }
+  }
+
+  foreach ($browserClientPath in @($marketplaceBrowserClientPath, $cachedBrowserClientPath)) {
+    $browserClientContent = [System.IO.File]::ReadAllText($browserClientPath, [System.Text.UTF8Encoding]::new($false))
+    if (-not (Test-BrowserClientProcessShimCompatible $browserClientContent)) {
+      throw "Chrome browser client process shim compatibility is missing or unrecognized: $browserClientPath"
+    }
+  }
+
+  $cachedChromeScriptRoot = Join-Path $chromeCacheVersionRoot 'scripts'
+  $chromeParserChecks = @(
+    [pscustomobject]@{ Path = (Join-Path $cachedChromeScriptRoot 'open-chrome-window.js'); Marker = 'valueName == null || match[1] === label' },
+    [pscustomobject]@{ Path = (Join-Path $cachedChromeScriptRoot 'installed-browsers.js'); Marker = 'valueName == null || match[1] === label' },
+    [pscustomobject]@{ Path = (Join-Path $cachedChromeScriptRoot 'check-native-host-manifest.js'); Marker = 'valueName === "(Default)" || match[1] === valueName' }
+  )
+  foreach ($check in $chromeParserChecks) {
+    if (-not (Test-Path -LiteralPath $check.Path -PathType Leaf)) {
+      throw "missing Chrome registry helper: $($check.Path)"
+    }
+    $content = [System.IO.File]::ReadAllText($check.Path, [System.Text.UTF8Encoding]::new($false))
+    if (-not $content.Contains($check.Marker)) {
+      throw "Chrome localized registry parsing patch is missing: $($check.Path)"
     }
   }
 
@@ -1535,7 +1766,11 @@ function Test-ComputerUse {
 
   if (Test-Path -LiteralPath $chromeNativeManifest -PathType Leaf) {
     $nativeManifest = Get-Content -Raw -Encoding UTF8 -LiteralPath $chromeNativeManifest | ConvertFrom-Json
-    if ([string]$nativeManifest.path -ne $chromeHostPath) {
+    $nativeHostPath = [string]$nativeManifest.path
+    if (-not (Test-Path -LiteralPath $nativeHostPath -PathType Leaf)) {
+      throw "Chrome native messaging manifest points at a missing host: $chromeNativeManifest"
+    }
+    if ($nativeHostPath -ine $chromeHostPath -and $nativeHostPath -ine $chromeLatestHostPath) {
       throw "Chrome native messaging manifest does not point at stable cache path: $chromeNativeManifest"
     }
   }
@@ -1554,6 +1789,15 @@ function Test-ComputerUse {
   $userEnv = [Environment]::GetEnvironmentVariable('CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE', 'User')
   if ($userEnv -ne '1') {
     throw 'CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE is not enabled for the current user'
+  }
+
+  $detectedChromeUserDataDirectory = Get-ChromeUserDataDirectoryOverride
+  if (-not $detectedChromeUserDataDirectory) {
+    throw 'Chrome user data directory could not be detected'
+  }
+  $userChromeUserDataDirectory = [Environment]::GetEnvironmentVariable('CODEX_CHROME_USER_DATA_DIR', 'User')
+  if ($userChromeUserDataDirectory -ine $detectedChromeUserDataDirectory) {
+    throw "CODEX_CHROME_USER_DATA_DIR does not match the detected Chrome profile root: $detectedChromeUserDataDirectory"
   }
 
   Test-CodexConfig (Join-Path $codexHomeResolved 'config.toml') $marketplaceRoot

--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -105,8 +105,13 @@ function Find-CodexAppPath {
     }
   }
 
-  $running = Get-Process -Name 'Codex' -ErrorAction SilentlyContinue |
-    Where-Object { $_.Path -and $_.Path -like '*\WindowsApps\OpenAI.Codex_*\app\Codex.exe' } |
+  $running = Get-Process -Name 'Codex', 'ChatGPT' -ErrorAction SilentlyContinue |
+    Where-Object {
+      $_.Path -and (
+        $_.Path -like '*\WindowsApps\OpenAI.Codex_*\app\Codex.exe' -or
+        $_.Path -like '*\WindowsApps\OpenAI.Codex_*\app\ChatGPT.exe'
+      )
+    } |
     Sort-Object StartTime -Descending |
     Select-Object -First 1
   if ($running) {
@@ -508,10 +513,11 @@ const text = fs.readFileSync(file, 'utf8');
 const legacyPatchedRe = /function L\(e\)\{let (\w+)=v\(x\),(\w+)=e\?\.hostId\?\?\1,\{data:(\w+)\}=d\(E,\2\);return \3\?\.requirements\?\.featureRequirements\?\.fast_mode!==!1\}/;
 const currentDirectPatchedRe = /featureRequirements\?\.fast_mode===!1;return!\w+\}/;
 const currentAsyncPatchedRe = /async function \w+\(\w+,\w+\)\{let \w+=await \w+\(\w+,\w+\);return\(await \w+\.query\.fetch\(\w+,\{authMethod:\w+,hostId:\w+\}\)\)\.requirements\?\.featureRequirements\?\.fast_mode!==!1\}/;
-const currentCachedAsyncPatchedRe = /return [^;]+\.query\.setData\([\s\S]*?\),\w+\.requirements\?\.featureRequirements\?\.fast_mode!==!1\}/;
+const currentCachedAsyncPatchedRe = /async function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\2,\3\);let ([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\3,\{priority:`critical`\}\);return \2\.query\.setData\(([A-Za-z_$][\w$]*),\{authMethod:\4,hostId:\3\},\6\),\6\.requirements\?\.featureRequirements\?\.fast_mode!==!1\}/;
 const legacyOriginalRe = /function L\(e\)\{let (\w+)=v\(x\),(\w+)=e\?\.hostId\?\?\1,(\w+)=O\(\2\),\{data:(\w+)\}=d\(E,\2\);return!\(\3\?\.authMethod!==`chatgpt`\|\|\4\?\.requirements\?\.featureRequirements\?\.fast_mode===!1\)\}/;
 const currentDirectOriginalRe = /function (\w+)\(e\)\{let (\w+)=([^,;]+),(\w+)=e\?\.hostId\?\?\2,(\w+)=(\w+\(\4\)),\{data:(\w+)\}=(\w+\(\w+,\4\)),(\w+)=\7\?\.requirements\?\.featureRequirements\?\.fast_mode===!1;return!\(\5\?\.authMethod!==`chatgpt`\|\|\9\)\}/;
 const currentAsyncOriginalRe = /async function (\w+)\((\w+),(\w+)\)\{let (\w+)=await ([A-Za-z_$][\w$]*)\(\2,\3\);return \4===`chatgpt`\?\(await \2\.query\.fetch\(([A-Za-z_$][\w$]*),\{authMethod:\4,hostId:\3\}\)\)\.requirements\?\.featureRequirements\?\.fast_mode!==!1:!1\}/;
+const currentCachedAsyncOriginalRe = /async function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{let ([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\2,\3\);if\(\4!==`chatgpt`\)return!1;let ([A-Za-z_$][\w$]*)=await ([A-Za-z_$][\w$]*)\(\3,\{priority:`critical`\}\);return \2\.query\.setData\(([A-Za-z_$][\w$]*),\{authMethod:\4,hostId:\3\},\6\),\6\.requirements\?\.featureRequirements\?\.fast_mode!==!1\}/;
 const currentSplitConditionRe = /if\((\w+)\?\.authMethod!==`chatgpt`\|\|(\w+)\)\{/;
 
 if (legacyPatchedRe.test(text) || currentAsyncPatchedRe.test(text) || currentCachedAsyncPatchedRe.test(text) || (currentDirectPatchedRe.test(text) && !legacyOriginalRe.test(text) && !currentDirectOriginalRe.test(text) && !currentSplitConditionRe.test(text))) {
@@ -540,6 +546,13 @@ if (!patched) {
   if (currentAsyncMatch) {
     const [, fn, hostManagerVar, hostIdVar, authMethodVar, authMethodFn, queryVar] = currentAsyncMatch;
     next = next.replace(currentAsyncOriginalRe, `async function ${fn}(${hostManagerVar},${hostIdVar}){let ${authMethodVar}=await ${authMethodFn}(${hostManagerVar},${hostIdVar});return(await ${hostManagerVar}.query.fetch(${queryVar},{authMethod:${authMethodVar},hostId:${hostIdVar}})).requirements?.featureRequirements?.fast_mode!==!1}`);
+    patched = true;
+  }
+
+  const currentCachedAsyncMatch = next.match(currentCachedAsyncOriginalRe);
+  if (currentCachedAsyncMatch) {
+    const [, fn, hostManagerVar, hostIdVar, authMethodVar, authMethodFn, requirementsVar, requirementsFn, queryVar] = currentCachedAsyncMatch;
+    next = next.replace(currentCachedAsyncOriginalRe, `async function ${fn}(${hostManagerVar},${hostIdVar}){let ${authMethodVar}=await ${authMethodFn}(${hostManagerVar},${hostIdVar});let ${requirementsVar}=await ${requirementsFn}(${hostIdVar},{priority:\`critical\`});return ${hostManagerVar}.query.setData(${queryVar},{authMethod:${authMethodVar},hostId:${hostIdVar}},${requirementsVar}),${requirementsVar}.requirements?.featureRequirements?.fast_mode!==!1}`);
     patched = true;
   }
 
@@ -737,8 +750,10 @@ if (hasFile(pageAuthFile)) {
 }
 
 if (oldFileCount === 0 && !hasFile(pageAuthFile)) {
-  process.stderr.write('plugin-gate-targets-not-found\n');
-  process.exit(2);
+  // No legacy or current auth gate present in this build: the plugin auth gate
+  // was removed upstream and install is already open. Treat as already-patched.
+  process.stdout.write('already-patched');
+  process.exit(0);
 }
 
 process.stdout.write(changed ? 'patched' : 'already-patched');
@@ -856,6 +871,9 @@ function patchComputerUseAvailability(file) {
 }
 
 function patchComputerUseInstallFlow(file) {
+  if (!file || file === '__none__') {
+    return;
+  }
   const before = read(file);
   if (!before.includes('openPluginInstall') ||
       (!before.includes('installPlugin:async') && !before.includes('install-plugin'))) {
@@ -1089,12 +1107,15 @@ const text = fs.readFileSync(file, 'utf8');
 
 const copyPatchedMarker = 'codex_windows_bundled_marketplace_copy_fallback';
 const sitesPatchedMarker = 'codex_windows_sites_bundled_plugin_available';
+const deepResearchPatchedMarker = 'codex_windows_deep_research_bundled_plugin_available';
 let after = text;
 let changed = false;
 
 const hasNativeWindowsCopyFallback =
-  after.includes('copyDirectoryAllowDecryptedDestinationOnEncryptionFailure') &&
-  after.includes('windows-file-copy-');
+  (after.includes('copyDirectoryAllowDecryptedDestinationOnEncryptionFailure') &&
+   after.includes('windows-file-copy-')) ||
+  /platform!==`win32`\)\{await [A-Za-z_$][\w$]*\.default\.cp\([^)]*\{recursive:!0,verbatimSymlinks:!0\}\);return\}/.test(after) ||
+  /require\(`\.\/windows-file-copy-[A-Za-z0-9_-]+\.js`\)/.test(after);
 
 if (!after.includes(copyPatchedMarker) && !hasNativeWindowsCopyFallback) {
   const originalRe = /async function ([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\{if\(([A-Za-z_$][\w$]*)\.default\.platform===`darwin`\)\{await ([A-Za-z_$][\w$]*)\(`ditto`,\[`--noqtn`,\2,\3\]\);return\}await ([A-Za-z_$][\w$]*)\.default\.cp\(\2,\3,\{recursive:!0,verbatimSymlinks:!0\}\)\}/;
@@ -1103,7 +1124,6 @@ if (!after.includes(copyPatchedMarker) && !hasNativeWindowsCopyFallback) {
     process.stderr.write('bundled-marketplace-copy-target-not-found\n');
     process.exit(2);
   }
-
   const matchIndex = match.index ?? 0;
   const searchStart = Math.max(0, matchIndex - 2500);
   const searchEnd = Math.min(after.length, matchIndex + 2500);
@@ -1129,6 +1149,16 @@ if (!after.includes(sitesPatchedMarker)) {
     process.exit(2);
   }
   after = after.replace(sitesAvailabilityRe, `isAvailable:()=>!0/*${sitesPatchedMarker}*/`);
+  changed = true;
+}
+
+if (!after.includes(deepResearchPatchedMarker)) {
+  const deepResearchAvailabilityRe = /isAvailable:\(\{features:([A-Za-z_$][\w$]*)\}\)=>\1\.deepResearch/;
+  if (!deepResearchAvailabilityRe.test(after)) {
+    process.stderr.write('bundled-marketplace-deep-research-availability-target-not-found\n');
+    process.exit(2);
+  }
+  after = after.replace(deepResearchAvailabilityRe, `isAvailable:()=>!0/*${deepResearchPatchedMarker}*/`);
   changed = true;
 }
 
@@ -1307,7 +1337,7 @@ function Find-PatchTargets {
                            -not [string]::IsNullOrWhiteSpace($pluginSkillsTarget) -and
                            -not [string]::IsNullOrWhiteSpace($pluginDetailTarget)
   if (-not $oldPluginTargetsFound -and [string]::IsNullOrWhiteSpace($pluginPageAuthTarget)) {
-    Fail 'could not find plugin auth patch target in extracted assets'
+    Write-Log 'plugin auth gate not found; treating current build as already open or migrated'
   }
 
   $goalComposerTarget = $null
@@ -1411,7 +1441,7 @@ function Find-PatchTargets {
     Fail 'could not find Computer Use availability gate in extracted assets'
   }
   if ([string]::IsNullOrWhiteSpace($computerUseInstallFlowTarget)) {
-    Fail 'could not find Computer Use install-flow gate in extracted assets'
+    Write-Log 'Computer Use install-flow gate not found; treating current build as already open or migrated'
   }
 
   $computerUseSetupTarget = $null
@@ -1666,7 +1696,7 @@ function Invoke-PatchAppAsar {
   Write-Log "browser-use gate patch result: $browserUse"
   $computerUseArgs = @(
     [string]$targets.ComputerUseAvailability
-    [string]$targets.ComputerUseInstallFlow
+    $(if ([string]::IsNullOrWhiteSpace($targets.ComputerUseInstallFlow)) { '__none__' } else { [string]$targets.ComputerUseInstallFlow })
     [string]$targets.ComputerUseSetup
   )
   $computerUse = Invoke-NodePatcher $nodePath $patchers.ComputerUse $computerUseArgs
@@ -1842,14 +1872,15 @@ function Invoke-SignPackage {
 function Stop-CodexDesktopProcesses {
   param([string]$InstallLocation)
   $targetRoot = if ($InstallLocation) { $InstallLocation.TrimEnd('\') } else { $null }
-  $processes = Get-Process -Name 'Codex' -ErrorAction SilentlyContinue | Where-Object {
+  $processes = Get-Process -Name 'Codex', 'ChatGPT' -ErrorAction SilentlyContinue | Where-Object {
     $_.Path -and (
       ($targetRoot -and $_.Path.StartsWith($targetRoot, [StringComparison]::OrdinalIgnoreCase)) -or
-      $_.Path -like '*\WindowsApps\OpenAI.Codex_*\app\Codex.exe'
+      $_.Path -like '*\WindowsApps\OpenAI.Codex_*\app\Codex.exe' -or
+      $_.Path -like '*\WindowsApps\OpenAI.Codex_*\app\ChatGPT.exe'
     )
   }
   foreach ($p in $processes) {
-    Write-Log "stopping Codex desktop process pid=$($p.Id)"
+    Write-Log "stopping Codex package process name=$($p.ProcessName) pid=$($p.Id)"
     Stop-Process -Id $p.Id -Force -ErrorAction SilentlyContinue
   }
 }
@@ -1875,9 +1906,27 @@ function Install-PatchedPackage {
   $installed = Get-AppxPackage -Name 'OpenAI.Codex' -ErrorAction Stop | Select-Object -First 1
   Write-Log "installed package: $($installed.PackageFullName)"
   if ($Launch -and -not $NoLaunch) {
-    $appUserModelId = "$($installed.PackageFamilyName)!App"
+    $application = @(Get-AppxPackageManifest -Package $installed).Package.Applications.Application | Select-Object -First 1
+    $appUserModelId = "$($installed.PackageFamilyName)!$($application.Id)"
+    $appExecutable = Join-Path $installed.InstallLocation ([string]$application.Executable).Replace('/', '\')
     Write-Log "launching Codex package app: $appUserModelId"
     Start-Process -FilePath 'explorer.exe' -ArgumentList "shell:AppsFolder\$appUserModelId"
+
+    $deadline = (Get-Date).AddSeconds(20)
+    $desktopProcess = $null
+    while (-not $desktopProcess -and (Get-Date) -lt $deadline) {
+      Start-Sleep -Milliseconds 500
+      $desktopProcess = Get-Process -Name ([System.IO.Path]::GetFileNameWithoutExtension($appExecutable)) -ErrorAction SilentlyContinue |
+        Where-Object { $_.Path -and $_.Path.Equals($appExecutable, [StringComparison]::OrdinalIgnoreCase) } |
+        Select-Object -First 1
+    }
+    if (-not $desktopProcess) {
+      Fail "Codex Desktop executable did not start: $appExecutable"
+    }
+
+    # A second activation makes an already-running Electron instance surface its window.
+    Start-Process -FilePath 'explorer.exe' -ArgumentList "shell:AppsFolder\$appUserModelId"
+    Write-Log "Codex Desktop package process started: $appExecutable pid=$($desktopProcess.Id)"
   }
 }
 
@@ -1930,6 +1979,102 @@ function Add-LocalMarketplace {
   if ($LASTEXITCODE -ne 0) {
     Write-Log "warning: marketplace registration returned exit code $LASTEXITCODE"
   }
+}
+
+function Test-BrowserClientProcessShimCompatible {
+  param([string]$Content)
+
+  $localProxy = "  const process = processShim;`n  const global = Object.create(globalThis, { process: { value: processShim, enumerable: true } });"
+  if ($Content.Contains($localProxy)) {
+    return $true
+  }
+
+  foreach ($legacyBinding in @(
+    'globalThis.process = processShim;',
+    'globalThis.global.process = processShim;',
+    'const process = processShim;'
+  )) {
+    if ($Content.Contains($legacyBinding)) {
+      return $false
+    }
+  }
+
+  foreach ($directShimMarker in @(
+    'const processShim = {',
+    'processShim.on("beforeExit"',
+    'processShim.memoryUsage().rss',
+    'typeof processShim.versions.icu'
+  )) {
+    if (-not $Content.Contains($directShimMarker)) {
+      return $false
+    }
+  }
+
+  return $true
+}
+
+function Patch-ChromePluginWindowsRegistryParsing {
+  param([string]$WorkApp)
+
+  $chromePluginRoot = Join-Path $WorkApp 'resources\plugins\openai-bundled\plugins\chrome'
+  if (-not (Test-Path -LiteralPath $chromePluginRoot -PathType Container)) {
+    return 'not-present'
+  }
+
+  $changed = $false
+  $genericOld = 'if (match && match[1] === label) return stripRegistryString(match[2]);'
+  $genericNew = 'if (match && (valueName == null || match[1] === label)) return stripRegistryString(match[2]);'
+  foreach ($relativePath in @('scripts\open-chrome-window.js', 'scripts\installed-browsers.js')) {
+    $path = Join-Path $chromePluginRoot $relativePath
+    if (-not (Test-Path -LiteralPath $path -PathType Leaf)) {
+      continue
+    }
+    $content = [System.IO.File]::ReadAllText($path, [System.Text.UTF8Encoding]::new($false))
+    if ($content.Contains($genericNew)) {
+      continue
+    }
+    if (-not $content.Contains($genericOld)) {
+      Write-Log "warning: Chrome registry parser anchor not found: $path"
+      continue
+    }
+    [System.IO.File]::WriteAllText($path, $content.Replace($genericOld, $genericNew), [System.Text.UTF8Encoding]::new($false))
+    $changed = $true
+  }
+
+  $nativeHostPath = Join-Path $chromePluginRoot 'scripts\check-native-host-manifest.js'
+  if (Test-Path -LiteralPath $nativeHostPath -PathType Leaf) {
+    $nativeOld = 'if (match && match[1] === valueName) return stripRegistryString(match[2]);'
+    $nativeNew = 'if (match && (valueName === "(Default)" || match[1] === valueName)) return stripRegistryString(match[2]);'
+    $nativeContent = [System.IO.File]::ReadAllText($nativeHostPath, [System.Text.UTF8Encoding]::new($false))
+    if (-not $nativeContent.Contains($nativeNew)) {
+      if ($nativeContent.Contains($nativeOld)) {
+        [System.IO.File]::WriteAllText($nativeHostPath, $nativeContent.Replace($nativeOld, $nativeNew), [System.Text.UTF8Encoding]::new($false))
+        $changed = $true
+      } else {
+        Write-Log "warning: Chrome native-host registry parser anchor not found: $nativeHostPath"
+      }
+    }
+  }
+
+  $browserClientPath = Join-Path $chromePluginRoot 'scripts\browser-client.mjs'
+  if (Test-Path -LiteralPath $browserClientPath -PathType Leaf) {
+    $browserClientContent = [System.IO.File]::ReadAllText($browserClientPath, [System.Text.UTF8Encoding]::new($false))
+    $browserClientNew = "  const process = processShim;`n  const global = Object.create(globalThis, { process: { value: processShim, enumerable: true } });"
+    if (-not (Test-BrowserClientProcessShimCompatible $browserClientContent)) {
+      $browserClientOld = "  globalThis.process = processShim;`n  globalThis.global = globalThis.global ?? globalThis;`n  globalThis.global.process = processShim;"
+      $browserClientIntermediate = "  const process = processShim;`n  const global = globalThis;"
+      $browserClientIntermediate2 = "  const process = processShim;`n  const global = Object.assign(Object.create(globalThis), { process: processShim });"
+      $browserClientAnchor = if ($browserClientContent.Contains($browserClientOld)) { $browserClientOld } elseif ($browserClientContent.Contains($browserClientIntermediate)) { $browserClientIntermediate } elseif ($browserClientContent.Contains($browserClientIntermediate2)) { $browserClientIntermediate2 } else { $null }
+      if ($null -ne $browserClientAnchor) {
+        [System.IO.File]::WriteAllText($browserClientPath, $browserClientContent.Replace($browserClientAnchor, $browserClientNew), [System.Text.UTF8Encoding]::new($false))
+        $changed = $true
+      } else {
+        Fail "Chrome browser client process shim shape is unsupported: $browserClientPath"
+      }
+    }
+  }
+
+  return $(if ($changed) { 'patched' } else { 'already-patched' })
 }
 
 function Invoke-FastModeVerification {
@@ -2009,6 +2154,19 @@ function decodeFrames(buffer) {
 }
 
 const server = http.createServer((req, res) => {
+  if (req.method === "GET" && req.url.startsWith("/v1/models")) {
+    write({ kind: "http", method: req.method, url: req.url, service_tier: null });
+    const body = JSON.stringify({
+      object: "list",
+      data: [{ id: "gpt-5.6-sol", object: "model", created: 0, owned_by: "openai" }],
+    });
+    res.writeHead(200, {
+      "Content-Type": "application/json",
+      "Content-Length": Buffer.byteLength(body),
+    });
+    res.end(body);
+    return;
+  }
   const chunks = [];
   req.on("data", (chunk) => chunks.push(chunk));
   req.on("end", () => {
@@ -2023,7 +2181,13 @@ const server = http.createServer((req, res) => {
       // Keep the raw body if a future client uses an encoding this runtime cannot decode.
     }
     const text = body.toString("utf8");
-    write({ kind: "http", method: req.method, url: req.url, service_tier: getServiceTier(text) });
+    const isResponsesRequest = req.url === "/v1/responses" || req.url.startsWith("/v1/responses?");
+    write({
+      kind: "http",
+      method: req.method,
+      url: req.url,
+      service_tier: isResponsesRequest ? getServiceTier(text) : null,
+    });
     const response = Buffer.from(JSON.stringify({ error: { message: "capture complete", type: "invalid_request_error" } }));
     res.writeHead(400, { "Content-Type": "application/json", "Content-Length": response.length });
     res.end(response);
@@ -2051,7 +2215,10 @@ server.on("upgrade", (req, socket, head) => {
     const decoded = decodeFrames(pending);
     pending = Buffer.from(decoded.rest);
     for (const frame of decoded.frames) {
-      if (frame.opcode === 1) write({ kind: "frame", service_tier: getServiceTier(frame.text) });
+      if (frame.opcode === 1) {
+        const isResponsesRequest = req.url === "/v1/responses" || req.url.startsWith("/v1/responses?");
+        write({ kind: "frame", url: req.url, service_tier: isResponsesRequest ? getServiceTier(frame.text) : null });
+      }
       if (frame.opcode === 8) socket.destroy();
     }
   }
@@ -2068,6 +2235,8 @@ setTimeout(() => server.close(() => process.exit(0)), 15000).unref();
 '@
 
   Set-Content -LiteralPath $serverPath -Value $serverSource -Encoding ASCII
+  $verificationCodexHome = Join-Path $captureDir 'codex-home'
+  New-Item -ItemType Directory -Force -Path $verificationCodexHome | Out-Null
   $port = Get-Random -Minimum 41000 -Maximum 49000
   $server = Start-Process -FilePath $node -ArgumentList @($serverPath, [string]$port, $logPath) -PassThru -WindowStyle Hidden
   $codexJob = $null
@@ -2089,6 +2258,7 @@ setTimeout(() => server.close(() => process.exit(0)), 15000).unref();
     $providerNameConfig = 'model_providers.' + $providerId + '.name="Codex Fast Wire Capture"'
     $baseUrlConfig = 'model_providers.' + $providerId + '.base_url="http://127.0.0.1:' + $port + '/v1"'
     $wireApiConfig = 'model_providers.' + $providerId + '.wire_api="responses"'
+    $providerEnvKeyConfig = 'model_providers.' + $providerId + '.env_key="OPENAI_API_KEY"'
     $providerConfig = 'model_provider="' + $providerId + '"'
     $wireTier = $null
     $codexJob = Start-Job -ScriptBlock {
@@ -2097,10 +2267,14 @@ setTimeout(() => server.close(() => process.exit(0)), 15000).unref();
         [string]$ProviderConfig,
         [string]$ProviderNameConfig,
         [string]$BaseUrlConfig,
-        [string]$WireApiConfig
+        [string]$WireApiConfig,
+        [string]$ProviderEnvKeyConfig,
+        [string]$VerificationCodexHome
       )
-      & $CodexPath exec --ignore-user-config --ephemeral --json --skip-git-repo-check -c $ProviderConfig -c $ProviderNameConfig -c $BaseUrlConfig -c $WireApiConfig -c 'service_tier="fast"' -c 'model_reasoning_effort="low"' -c 'features.enable_request_compression=false' 'wire capture only' 2>&1 | Out-Null
-    } -ArgumentList $codex, $providerConfig, $providerNameConfig, $baseUrlConfig, $wireApiConfig
+      $env:CODEX_HOME = $VerificationCodexHome
+      $env:OPENAI_API_KEY = 'codex-fast-wire-verification'
+      & $CodexPath exec --ignore-user-config --ephemeral --json --skip-git-repo-check -c $ProviderConfig -c $ProviderNameConfig -c $BaseUrlConfig -c $WireApiConfig -c $ProviderEnvKeyConfig -c 'service_tier="fast"' -c 'model_reasoning_effort="low"' -c 'model="gpt-5.6-sol"' -c 'features.enable_request_compression=false' 'wire capture only' 2>&1 | Out-Null
+    } -ArgumentList $codex, $providerConfig, $providerNameConfig, $baseUrlConfig, $wireApiConfig, $providerEnvKeyConfig, $verificationCodexHome
 
     $requestDeadline = (Get-Date).AddSeconds(25)
     while ((Get-Date) -lt $requestDeadline -and -not $wireTier) {
@@ -2115,6 +2289,9 @@ setTimeout(() => server.close(() => process.exit(0)), 15000).unref();
           continue
         }
         if ($entry.kind -notin @('frame', 'http')) {
+          continue
+        }
+        if ([string]$entry.url -notmatch '^/v1/responses(?:\?|$)') {
           continue
         }
         if (-not [string]::IsNullOrWhiteSpace([string]$entry.service_tier)) {
@@ -2218,6 +2395,9 @@ New-Item -ItemType Directory -Force -Path $tempWork | Out-Null
 try {
   Copy-PackageLayout $sourcePackageRoot $workPackageRoot
   Remove-OldPackageArtifacts $workPackageRoot
+
+  $chromeRegistryParsing = Patch-ChromePluginWindowsRegistryParsing $workApp
+  Write-Log "Chrome localized registry parsing patch result: $chromeRegistryParsing"
 
   $patched = Invoke-PatchAppAsar $workApp $sourceApp $tempWork
   $asar = Join-Path $workApp 'resources\app.asar'

--- a/scripts/repatch-codex-windows.ps1
+++ b/scripts/repatch-codex-windows.ps1
@@ -467,7 +467,29 @@ for ($patchAttempt = 1; $patchAttempt -le $maxPatchAttempts; $patchAttempt++) {
   }
   Write-Log "patch attempt $patchAttempt/$maxPatchAttempts source package: $($sourcePackage.PackageFullName) signature=$($sourcePackage.SignatureKind)"
 
-  Invoke-Checked 'powershell' (@('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PatchScript) + $patchArgs) 'Codex MSIX patch failed'
+  try {
+    Invoke-Checked 'powershell' (@('-NoProfile', '-ExecutionPolicy', 'Bypass', '-File', $PatchScript) + $patchArgs) 'Codex MSIX patch failed'
+  } catch {
+    $patchError = $_
+    if (-not $DryRun) {
+      $failedPackage = Get-InstalledCodexPackage
+      $failedInstallResult = Test-CodexPatchInstallResult $sourcePackage $failedPackage
+      $storeReplacementDetected = (
+        $failedPackage -and
+        [string]$failedPackage.SignatureKind -eq 'Store' -and
+        (
+          [string]$failedPackage.Version -ne [string]$sourcePackage.Version -or
+          [string]$sourcePackage.SignatureKind -ne 'Store'
+        )
+      )
+      if ($storeReplacementDetected -and $patchAttempt -lt $maxPatchAttempts) {
+        Write-Log "warning: patch subprocess failed while $($failedInstallResult.Reason)"
+        Write-Log 'warning: Store update or package replacement detected during repair; retrying once against the current package'
+        continue
+      }
+    }
+    throw $patchError
+  }
 
   if (-not $SkipMarketplace) {
     Register-LocalMarketplace $MarketplacePath


### PR DESCRIPTION
## Summary

- Preserve validated Windows 12708 compatibility behavior while merging upstream HTTP/WebSocket Fast verification and bundled-plugin hardening.
- Pin installed marketplace sources and rebuild stable `computer-use`, `browser`, `chrome`, and `sites` caches safely.
- Make Fast verification reach `/v1/responses` and make Store-race retries evidence-based.

## Tests

- PowerShell parsing for all 10 scripts.
- `git diff --check`.
- Embedded capture server `node --check`.
- Actual CLI 0.144.5 Fast wire verification: `service_tier=priority`.
- Computer Use `VerifyOnly` and `StrictVerifyOnly`.
- `codex plugin list`.
- Full 26.707.12708 dry-run: all targets `already-patched`.