### PR TITLE
[codex] support Codex 26.810 model visibility

### DIFF
--- a/references/restriction-debug-cases.md
+++ b/references/restriction-debug-cases.md
@@ -22,12 +22,14 @@ Checks:
 - Inspect `webview\assets\model-list-filter-*.js` for Statsig-driven `available_models` filtering. Provider discovery can succeed while the frontend still removes the model before the Power slider calculates its available combinations.
 - Inspect the asset containing `chatgpt-user-settings`, `model_picker_persists_ultra_effort`, and `showUltraInModelPickerSlider`. A settings control shaped like `disabled: data == null || mutation.isPending` is permanently disabled when a custom provider has no ChatGPT account user-settings response. The local TOML key alone is not enough if the build uses it only as a one-time migration flag.
 - Codex Desktop `26.721.3996.0` can merge the Fast UI gate and model-list filter into `webview\assets\app-initial-*.js`. Match the same stable behavior (`isServiceTierAllowed`, `available_models`, `useHiddenModels`, and `supportedReasoningEfforts`) before concluding that the gate was removed.
+- Codex Desktop `26.810.4967.0` adds a `model !== codex-auto-review` guard before the hidden-model ternary: `available?.has(model.model) === true || model.model !== codex-auto-review && (showHidden && !customProvider && authMethod !== amazonBedrock ? availableModels.has(model.model) : !model.hidden)`. An older patcher that only recognizes the parenthesized `amazonBedrock` form fails with `could not find custom model visibility filter in extracted assets`; treat that as matcher drift, not evidence that custom-model filtering disappeared.
 
 Action:
 
 - For CPA, add an override rule for the Codex-facing model names and force `service_tier` as a string value of `priority`.
 - Patch the Fast Mode gate by removing the `chatgpt`-only branch while preserving the feature-requirement lookup, then rerun wire capture.
 - Patch Ultra persistence with a guarded fallback: keep the official account API for successful ChatGPT user-settings queries, but on query failure return a local-backed state, write `show-ultra-in-model-picker-slider` locally, and do not let the one-time migration clear that local value after a failed remote write. Verify both the toggle state after restart and Ultra's presence in the actual compact slider.
+- When adding support for the `26.810` visibility predicate, retain the historical conditional and `amazonBedrock` predicate shapes. Run `scripts\test-custom-model-visibility-patterns.ps1 -TemporaryRoot <D-drive-child>` before a real-package dry run so old Store builds remain patchable.
 - Run the unified Model Experience dry run so the request gate, UI gate, and model filter are checked separately and only broken components are changed:
 
 ```powershell

--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -641,6 +641,11 @@ if (text.includes(marker) && models.every((model) => text.includes(model))) {
 
 const visibilityPatterns = [
   {
+    re: /return ([$A-Za-z_][$\w]*)\?\.has\(([$A-Za-z_][$\w]*)\.model\)===!0\|\|\2\.model!==`codex-auto-review`&&\(([$A-Za-z_][$\w]*)&&!([$A-Za-z_][$\w]*)&&([$A-Za-z_][$\w]*)!==`amazonBedrock`\?([$A-Za-z_][$\w]*)\.has\(\2\.model\):!\2\.hidden\)\}/,
+    modelGroup: 2,
+    isReturn: true,
+  },
+  {
     re: /if\(([$A-Za-z_][$\w]*)\?([$A-Za-z_][$\w]*)\.has\(([$A-Za-z_][$\w]*)\.model\):!\3\.hidden\)\{/,
     modelGroup: 3,
   },
@@ -1337,6 +1342,34 @@ if (changed) {
   }
 }
 
+function Test-CustomModelVisibilityExpression {
+  param(
+    [AllowNull()]
+    [string]$Text
+  )
+
+  if ([string]::IsNullOrEmpty($Text)) {
+    return $false
+  }
+  if ($Text.Contains('CODEX_CUSTOM_MODELS_V1')) {
+    return $true
+  }
+
+  # Keep target discovery aligned with the embedded Node patcher's supported predicate shapes.
+  $patterns = @(
+    'if\([$A-Za-z_][$\w]*\?[$A-Za-z_][$\w]*\.has\((?<model>[$A-Za-z_][$\w]*)\.model\):!\k<model>\.hidden\)\{',
+    'if\([$A-Za-z_][$\w]*\?\.has\((?<model>[$A-Za-z_][$\w]*)\.model\)===!0\|\|\([$A-Za-z_][$\w]*\?[$A-Za-z_][$\w]*\.has\(\k<model>\.model\):!\k<model>\.hidden\)\)\{',
+    '\?\.has\(\w+\.model\)===!0\|\|\(\w+(?:&&\w+!==`amazonBedrock`)?\?\w+\.has\(\w+\.model\):!\w+\.hidden\)',
+    '\?\.has\((?<model>[$A-Za-z_][$\w]*)\.model\)===!0\|\|\k<model>\.model!==`codex-auto-review`&&\((?<showHidden>[$A-Za-z_][$\w]*)&&!(?<customProvider>[$A-Za-z_][$\w]*)&&(?<authMethod>[$A-Za-z_][$\w]*)!==`amazonBedrock`\?(?<availableModels>[$A-Za-z_][$\w]*)\.has\(\k<model>\.model\):!\k<model>\.hidden\)'
+  )
+  foreach ($pattern in $patterns) {
+    if ($Text -match $pattern) {
+      return $true
+    }
+  }
+  return $false
+}
+
 function Find-PatchTargets {
   param(
     [string]$RgPath,
@@ -1402,8 +1435,7 @@ function Find-PatchTargets {
       if ($text.Contains('available_models') -and
           $text.Contains('useHiddenModels') -and
           $text.Contains('supportedReasoningEfforts') -and
-          (($text -match '\?\.has\(\w+\.model\)===!0\|\|\(\w+(?:&&\w+!==`amazonBedrock`)?\?\w+\.has\(\w+\.model\):!\w+\.hidden\)') -or
-           $text.Contains('CODEX_CUSTOM_MODELS_V1'))) {
+          (Test-CustomModelVisibilityExpression -Text $text)) {
         $customModelsTarget = $candidate
         break
       }
@@ -1852,8 +1884,7 @@ function Invoke-PatchAppAsar {
         if ($text.Contains('available_models') -and
             $text.Contains('useHiddenModels') -and
             $text.Contains('supportedReasoningEfforts') -and
-            (($text -match '\?\.has\(\w+\.model\)===!0\|\|\(\w+(?:&&\w+!==`amazonBedrock`)?\?\w+\.has\(\w+\.model\):!\w+\.hidden\)') -or
-             $text.Contains('CODEX_CUSTOM_MODELS_V1'))) {
+            (Test-CustomModelVisibilityExpression -Text $text)) {
           $customModelsTarget = $candidate
           break
         }

--- a/scripts/test-custom-model-visibility-patterns.ps1
+++ b/scripts/test-custom-model-visibility-patterns.ps1
@@ -1,0 +1,180 @@
+[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$TemporaryRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptPath = Join-Path $PSScriptRoot 'patch_codex_fast_mode_windows_msix.ps1'
+if (-not (Test-Path -LiteralPath $scriptPath -PathType Leaf)) {
+  throw "patch script is missing: $scriptPath"
+}
+
+$tokens = $null
+$parseErrors = $null
+$ast = [System.Management.Automation.Language.Parser]::ParseFile(
+  $scriptPath,
+  [ref]$tokens,
+  [ref]$parseErrors
+)
+if ($parseErrors.Count -ne 0) {
+  throw "patch script did not parse: $($parseErrors[0].Message)"
+}
+
+$functionAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.FunctionDefinitionAst] -and
+      $node.Name -ceq 'Test-CustomModelVisibilityExpression'
+  }, $true)
+if (-not $functionAst) {
+  throw 'custom model visibility expression helper was not found in the patch script'
+}
+$functionDefinition = [scriptblock]::Create($functionAst.Extent.Text)
+. $functionDefinition
+
+$patcherAst = $ast.Find({
+    param($node)
+    $node -is [System.Management.Automation.Language.StringConstantExpressionAst] -and
+      $node.Value.Contains("const marker = 'CODEX_CUSTOM_MODELS_V1';") -and
+      $node.Value.Contains('const visibilityPatterns = [')
+  }, $true)
+if (-not $patcherAst) {
+  throw 'embedded custom model patcher was not found in the patch script'
+}
+
+$node = Get-Command node.exe -ErrorAction SilentlyContinue
+if (-not $node) {
+  $node = Get-Command node -ErrorAction SilentlyContinue
+}
+if (-not $node) {
+  throw 'node is required for the custom model visibility regression test'
+}
+
+$temp = [System.IO.Path]::GetFullPath($TemporaryRoot)
+New-Item -ItemType Directory -Force -Path $temp | Out-Null
+$fixtureRoot = Join-Path $temp ('custom-model-visibility-' + [guid]::NewGuid().ToString('N'))
+New-Item -ItemType Directory -Force -Path $fixtureRoot | Out-Null
+$patcherPath = Join-Path $fixtureRoot 'PatchCustomModels.cjs'
+[System.IO.File]::WriteAllText(
+  $patcherPath,
+  $patcherAst.Value,
+  [System.Text.UTF8Encoding]::new($false)
+)
+
+$models = @('gpt-5.6-sol', 'gpt-5.6-terra', 'gpt-5.6-luna')
+$positiveFixtures = @(
+  [pscustomobject]@{
+    Name = 'legacy-conditional'
+    Source = 'function visible(a,b,c){if(a?b.has(c.model):!c.hidden){return true}return false}'
+  },
+  [pscustomobject]@{
+    Name = 'optional-has-conditional'
+    Source = 'function visible(a,b,c,d){if(a?.has(b.model)===!0||(c?d.has(b.model):!b.hidden)){return true}return false}'
+  },
+  [pscustomobject]@{
+    Name = 'amazon-bedrock-return'
+    Source = 'function visible(a,b,c,d,e){return a?.has(b.model)===!0||(c&&d!==`amazonBedrock`?e.has(b.model):!b.hidden)}'
+  },
+  [pscustomobject]@{
+    Name = 'codex-26-810-auto-review-return'
+    Source = 'function visible(e,i,a,r,t,n){return e?.has(i.model)===!0||i.model!==`codex-auto-review`&&(a&&!r&&t!==`amazonBedrock`?n.has(i.model):!i.hidden)}'
+  }
+)
+$negativeFixture = [pscustomobject]@{
+  Name = 'auto-review-unrelated-ternary'
+  Source = 'function visible(a,b,c,d){return a?.has(b.model)===!0||b.model!==`codex-auto-review`&&(c?d.has(b.model):!b.hidden)}'
+}
+
+function Invoke-NodePatcherFixture {
+  param(
+    [string]$Name,
+    [string]$Source,
+    [int]$ExpectedExitCode
+  )
+
+  $assetPath = Join-Path $fixtureRoot ($Name + '.js')
+  [System.IO.File]::WriteAllText(
+    $assetPath,
+    $Source,
+    [System.Text.UTF8Encoding]::new($false)
+  )
+  $arguments = @($patcherPath, $assetPath) + $models
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $ErrorActionPreference = 'Continue'
+    $output = @(& $node.Source @arguments 2>&1)
+    $exitCode = $LASTEXITCODE
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+  }
+  if ($exitCode -ne $ExpectedExitCode) {
+    throw "$Name patcher exit mismatch: expected=$ExpectedExitCode actual=$exitCode output=$($output -join ' | ')"
+  }
+  return [pscustomobject]@{
+    AssetPath = $assetPath
+    Output = (($output | ForEach-Object { [string]$_ }) -join "`n").Trim()
+  }
+}
+
+$previousNativePreference = $null
+$hasNativePreference = Test-Path Variable:\PSNativeCommandUseErrorActionPreference
+if ($hasNativePreference) {
+  $previousNativePreference = $PSNativeCommandUseErrorActionPreference
+  $PSNativeCommandUseErrorActionPreference = $false
+}
+try {
+  foreach ($fixture in $positiveFixtures) {
+    if (-not (Test-CustomModelVisibilityExpression -Text $fixture.Source)) {
+      throw "$($fixture.Name) was rejected by the PowerShell target matcher"
+    }
+
+    $result = Invoke-NodePatcherFixture -Name $fixture.Name -Source $fixture.Source -ExpectedExitCode 0
+    if ($result.Output -cne 'patched') {
+      throw "$($fixture.Name) did not report patched: $($result.Output)"
+    }
+    $patched = [System.IO.File]::ReadAllText($result.AssetPath)
+    if (-not $patched.Contains('CODEX_CUSTOM_MODELS_V1')) {
+      throw "$($fixture.Name) is missing the custom model patch marker"
+    }
+    foreach ($model in $models) {
+      if (-not $patched.Contains($model)) {
+        throw "$($fixture.Name) is missing patched model: $model"
+      }
+    }
+
+    $syntaxOutput = @(& $node.Source --check $result.AssetPath 2>&1)
+    $syntaxExitCode = $LASTEXITCODE
+    if ($syntaxExitCode -ne 0) {
+      throw "$($fixture.Name) produced invalid JavaScript: $($syntaxOutput -join ' | ')"
+    }
+
+    $secondArguments = @($patcherPath, $result.AssetPath) + $models
+    $secondOutput = @(& $node.Source @secondArguments 2>&1)
+    $secondExitCode = $LASTEXITCODE
+    if ($secondExitCode -ne 0 -or (($secondOutput -join "`n").Trim() -cne 'already-patched')) {
+      throw "$($fixture.Name) was not idempotent: exit=$secondExitCode output=$($secondOutput -join ' | ')"
+    }
+  }
+
+  if (Test-CustomModelVisibilityExpression -Text $negativeFixture.Source) {
+    throw "$($negativeFixture.Name) was accepted by the PowerShell target matcher"
+  }
+  $negativeResult = Invoke-NodePatcherFixture `
+    -Name $negativeFixture.Name `
+    -Source $negativeFixture.Source `
+    -ExpectedExitCode 2
+  if ($negativeResult.Output -cne 'custom-model-visibility-target-not-found') {
+    throw "$($negativeFixture.Name) failed for the wrong reason: $($negativeResult.Output)"
+  }
+
+  if (-not (Test-CustomModelVisibilityExpression -Text '/*CODEX_CUSTOM_MODELS_V1*/')) {
+    throw 'the PowerShell target matcher did not recognize an already-patched asset'
+  }
+} finally {
+  if ($hasNativePreference) {
+    $PSNativeCommandUseErrorActionPreference = $previousNativePreference
+  }
+}
+
+Write-Output "Custom model visibility predicate regression passed: $fixtureRoot"


### PR DESCRIPTION
## What changed

- Recognize the Codex Desktop `26.810.4967.0` custom-model visibility predicate with its `codex-auto-review` guard.
- Keep all previously supported conditional and `amazonBedrock` predicate shapes in target discovery and patching.
- Add AST-backed regression fixtures plus a version-drift entry in the restriction debugging guide.

## Root cause

Codex Desktop `26.810.4967.0` changed the minified model visibility expression. The existing matcher only recognized the older parenthesized provider predicate, so both full and `OnlyModelExperience` dry runs stopped with `could not find custom model visibility filter in extracted assets`.

## Validation

- Parsed all 24 PowerShell scripts successfully under Windows PowerShell.
- Ran `test-custom-model-visibility-patterns.ps1` against four supported predicate shapes, an already-patched pass, idempotence, JavaScript syntax checks, and a rejected near-match.
- Ran `OnlyModelExperience` DryRun against the exact original `26.810.4967.0` package copy; custom models reported `patched` and modified-asset syntax checks passed.
- Ran the full real-package DryRun against the same original package; all patch targets validated without signing, installing, or launching.
- Ran `git diff --cached --check`.

## Scope

No phone remote-control code, credentials, machine-specific paths, repair logs, package artifacts, or local Codex state are included.