### PR TITLE
fix: write the local marketplace JSON without a UTF-8 BOM

### DIFF
--- a/references/restriction-debug-cases.md
+++ b/references/restriction-debug-cases.md
@@ -172,6 +172,7 @@ Checks:
 - Inspect running `extension-host` processes whose paths are under `%USERPROFILE%\.codex\plugins\cache\openai-bundled`.
 - Inspect `%USERPROFILE%\.codex\chrome-native-hosts.json`; remove stale entries whose `extensionHostPath` or `browserClientPath` points to a missing file.
 - If the browser files and versioned cache exist but `codex plugin list` still reports `browser@openai-bundled` as `not installed`, do not treat another direct TOML write as a durable install. Desktop reconciliation can prune that enabled entry again because the CLI install record was never created.
+- If `codex plugin marketplace add` fails with `invalid marketplace file ...marketplace.json: expected value at line 1 column 1`, read the first three bytes of that file before suspecting its contents. A UTF-8 BOM makes the Rust JSON parser reject the whole document, and comparing the file with its source is misleading because PowerShell reads a BOM-prefixed file back without complaint.
 
 Action:
 
@@ -179,6 +180,7 @@ Action:
 - Stop only those bundled `extension-host` processes when they are locking the bundled marketplace mirror.
 - Rerun `scripts\install-computer-use-local.ps1`.
 - Let the repair register `browser@openai-bundled` through `codex plugin add ... --json` after the local marketplace is complete. On Windows, invoke a user-accessible CLI shim such as the npm `codex.cmd`; do not execute the protected `WindowsApps\...\resources\codex.exe` path directly.
+- Write every marketplace JSON as BOM-less UTF-8. `Set-Content -Encoding UTF8` emits a BOM on PowerShell 5.1, so a rewrite step can corrupt the registered copy while the source file stays valid; use `[System.IO.File]::WriteAllText` with `UTF8Encoding($false)`.
 - If the copy fails because a file under `.tmp\bundled-marketplaces\openai-bundled` disappears mid-read, treat it as Desktop reconciliation racing the repair. Stable plugin caches must be sourced from the installed package; only the locally modified Computer Use runtime is overlaid afterward.
 - Restart Codex Desktop.
 - Confirm the latest Desktop log ends with `computer-use native pipe startup ready`.

--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -2613,7 +2613,12 @@ function Add-LocalMarketplace {
   if ($json.metadata -and $json.metadata.displayName -eq 'Codex official') {
     $json.metadata.displayName = 'Codex official local'
   }
-  $json | ConvertTo-Json -Depth 100 | Set-Content -LiteralPath $jsonPath -Encoding UTF8
+  # Set-Content -Encoding UTF8 emits a BOM on PowerShell 5.1 and the Rust JSON parser
+  # then rejects the file with "expected value at line 1 column 1".
+  [System.IO.File]::WriteAllText(
+    $jsonPath,
+    ($json | ConvertTo-Json -Depth 100),
+    [System.Text.UTF8Encoding]::new($false))
   $codex = Find-CodexCli
   if (-not $codex) {
     Write-Log "codex CLI not found; marketplace copied but not registered: $dest"


### PR DESCRIPTION
`Add-LocalMarketplace` wrote `.agents\plugins\marketplace.json` with `Set-Content -Encoding UTF8`. On PowerShell 5.1 that emits a UTF-8 BOM, and the Rust JSON parser then rejects the file:

```
invalid marketplace file %USERPROFILE%\.agents\plugins\marketplace.json: expected value at line 1 column 1
```

`codex plugin marketplace add` and `codex plugin list` both fail until the BOM is removed, so a repatch that otherwise succeeds still leaves the local marketplace unusable.

The fix writes the file through `[System.IO.File]::WriteAllText` with `UTF8Encoding($false)`, which is BOM-less on PowerShell 5.1 and 7. `references/restriction-debug-cases.md` gains the first-three-bytes check (`EF BB BF`) for that exact error message and the corresponding action.

Verified on Windows 10 19045 with Desktop `26.818.3698.0`: after the fix the JSON starts with `{` and marketplace registration succeeds.