### PR TITLE
Accept the Desktop-managed app-server entry in Chrome native-host v2 state

### DIFF
--- a/scripts/install-computer-use-local.ps1
+++ b/scripts/install-computer-use-local.ps1
@@ -1779,7 +1779,8 @@ function Test-FilesMatchByContent {
 function Get-CurrentCodexAppServerRuntimeInventory {
   param(
     [string]$PackageResourcesRoot,
-    [string]$LocalCodexRoot = (Join-Path $env:LOCALAPPDATA 'OpenAI\Codex')
+    [string]$LocalCodexRoot = (Join-Path $env:LOCALAPPDATA 'OpenAI\Codex'),
+    [string]$CodexHomeRoot = $CodexHome
   )
 
   if ([string]::IsNullOrWhiteSpace($PackageResourcesRoot)) {
@@ -1812,6 +1813,15 @@ function Get-CurrentCodexAppServerRuntimeInventory {
       }
     }
   }
+  $desktopManagedCodexCliPaths = @()
+  $codexHomeForAppServer = $CodexHomeRoot
+  if ([string]::IsNullOrWhiteSpace($codexHomeForAppServer)) {
+    $codexHomeForAppServer = Join-Path $env:USERPROFILE '.codex'
+  }
+  $desktopManagedCodex = Join-Path $codexHomeForAppServer 'plugins\.plugin-appserver\codex.exe'
+  if (Test-FilesMatchByContent $desktopManagedCodex $packageCodex) {
+    $desktopManagedCodexCliPaths += [System.IO.Path]::GetFullPath($desktopManagedCodex)
+  }
   $cuaCandidates = @()
   $localCuaRoot = Join-Path $LocalCodexRoot 'runtimes\cua_node'
   if (Test-Path -LiteralPath $localCuaRoot -PathType Container) {
@@ -1842,6 +1852,7 @@ function Get-CurrentCodexAppServerRuntimeInventory {
     NodePath = $selectedCua.NodePath
     NodeReplPath = $selectedCua.NodeReplPath
     AllowedCodexCliPaths = @($codexCandidates | ForEach-Object { $_.Path })
+    DesktopManagedCodexCliPaths = @($desktopManagedCodexCliPaths)
     AllowedCuaBinRoots = @($cuaCandidates | ForEach-Object { $_.BinRoot })
     ReferenceCodexCliPath = $packageCodex
     ReferenceNodePath = $packageNode
@@ -2064,7 +2075,8 @@ function Get-ChromeNativeHostV2ExpectedResource {
   param(
     [string]$ChromeCacheRoot,
     [pscustomobject]$RuntimeInventory,
-    [string]$CodexHomeResolved
+    [string]$CodexHomeResolved,
+    [string]$CodexCliPathOverride
   )
 
   $settings = Get-ChromeNativeMessagingSettings $ChromeCacheRoot
@@ -2094,11 +2106,15 @@ function Get-ChromeNativeHostV2ExpectedResource {
   $nodeModuleRoot = Join-Path (Split-Path -Parent $RuntimeInventory.NodePath) 'node_modules'
   $browserClientPath = [string]$hostConfig.browserClientPath
   $browserServicePath = Join-Path (Split-Path -Parent $browserClientPath) 'browser-service.mjs'
+  $appServerCliPath = $RuntimeInventory.CodexCliPath
+  if (-not [string]::IsNullOrWhiteSpace($CodexCliPathOverride)) {
+    $appServerCliPath = $CodexCliPathOverride
+  }
   $requiredFiles = @(
     $extensionHostPath,
     $browserClientPath,
     $browserServicePath,
-    $RuntimeInventory.CodexCliPath,
+    $appServerCliPath,
     $RuntimeInventory.NodePath,
     $RuntimeInventory.NodeReplPath
   )
@@ -2116,7 +2132,7 @@ function Get-ChromeNativeHostV2ExpectedResource {
   $paths = [ordered]@{
     browserClientPath = $browserClientPath
     browserServicePath = $browserServicePath
-    codexCliPath = $RuntimeInventory.CodexCliPath
+    codexCliPath = $appServerCliPath
     codexHome = $CodexHomeResolved
     extensionHostPath = $extensionHostPath
     nodePath = $RuntimeInventory.NodePath
@@ -2165,6 +2181,27 @@ function Get-ChromeNativeHostV2ExpectedResource {
     proxyPort = 0
     updatedAt = $now
   }
+}
+
+function Get-ChromeNativeHostV2AcceptableResources {
+  param(
+    [string]$ChromeCacheRoot,
+    [pscustomobject]$RuntimeInventory,
+    [string]$CodexHomeResolved
+  )
+
+  $resources = @(Get-ChromeNativeHostV2ExpectedResource $ChromeCacheRoot $RuntimeInventory $CodexHomeResolved)
+  foreach ($desktopManagedPath in @($RuntimeInventory.DesktopManagedCodexCliPaths)) {
+    if ([string]::IsNullOrWhiteSpace($desktopManagedPath)) {
+      continue
+    }
+    if (Test-PathMatchesAnyCurrentFile $desktopManagedPath @($resources[0].paths.codexCliPath)) {
+      continue
+    }
+    $resources += (Get-ChromeNativeHostV2ExpectedResource `
+      $ChromeCacheRoot $RuntimeInventory $CodexHomeResolved -CodexCliPathOverride $desktopManagedPath)
+  }
+  return @($resources)
 }
 
 function Test-ChromeNativeHostV2JsonObject {
@@ -2419,9 +2456,14 @@ function Test-ChromeNativeHostV2EntryReplacedBy {
 function Write-ChromeNativeHostV2State {
   param(
     [string]$StatePath,
-    [pscustomobject]$ExpectedResource
+    [pscustomobject]$ExpectedResource,
+    [pscustomobject[]]$AcceptableResources
   )
 
+  $acceptable = @($AcceptableResources | Where-Object { $null -ne $_ })
+  if ($acceptable.Count -eq 0) {
+    $acceptable = @($ExpectedResource)
+  }
   $raw = $null
   $entries = @()
   if (Test-Path -LiteralPath $StatePath -PathType Leaf) {
@@ -2439,7 +2481,8 @@ function Write-ChromeNativeHostV2State {
   }
 
   $existingCurrent = @($entries | Where-Object {
-    Test-ChromeNativeHostV2EntryCoreEqual $_ $ExpectedResource
+    $entry = $_
+    @($acceptable | Where-Object { Test-ChromeNativeHostV2EntryCoreEqual $entry $_ }).Count -gt 0
   } | Select-Object -First 1)
   $resource = if ($existingCurrent.Count -gt 0) { $existingCurrent[0] } else { $ExpectedResource }
   $nextEntries = @($entries | Where-Object {
@@ -2490,7 +2533,7 @@ function Write-ChromeNativeHostV2State {
     Remove-Item -LiteralPath $temporaryPath -Force -ErrorAction SilentlyContinue
     Remove-Item -LiteralPath $replaceBackupPath -Force -ErrorAction SilentlyContinue
   }
-  Write-Log "updated Chrome native-host v2 state: $StatePath entry=$($ExpectedResource.entryId)"
+  Write-Log "updated Chrome native-host v2 state: $StatePath entry=$($resource.entryId)"
   return $true
 }
 
@@ -2501,9 +2544,10 @@ function Update-ChromeNativeHostV2State {
     [string]$CodexHomeResolved = (Resolve-OrCreateDirectory $CodexHome)
   )
 
-  $expected = Get-ChromeNativeHostV2ExpectedResource $ChromeCacheRoot $RuntimeInventory $CodexHomeResolved
+  $acceptable = @(Get-ChromeNativeHostV2AcceptableResources $ChromeCacheRoot $RuntimeInventory $CodexHomeResolved)
+  $expected = $acceptable[0]
   foreach ($statePath in @(Get-ChromeNativeHostV2StatePaths $CodexHomeResolved)) {
-    Write-ChromeNativeHostV2State $statePath $expected | Out-Null
+    Write-ChromeNativeHostV2State $statePath $expected -AcceptableResources $acceptable | Out-Null
   }
 }
 
@@ -2514,8 +2558,10 @@ function Test-ChromeNativeHostV2State {
     [string]$CodexHomeResolved = (Resolve-ExistingDirectory $CodexHome)
   )
 
-  $expected = Get-ChromeNativeHostV2ExpectedResource $ChromeCacheRoot $RuntimeInventory $CodexHomeResolved
+  $acceptable = @(Get-ChromeNativeHostV2AcceptableResources $ChromeCacheRoot $RuntimeInventory $CodexHomeResolved)
+  $expected = $acceptable[0]
   $verifiedPaths = @()
+  $matchedEntryIds = @()
   foreach ($statePath in @(Get-ChromeNativeHostV2StatePaths $CodexHomeResolved)) {
     if (-not (Test-Path -LiteralPath $statePath -PathType Leaf)) {
       throw "Chrome native-host v2 state is missing: $statePath"
@@ -2529,14 +2575,17 @@ function Test-ChromeNativeHostV2State {
       throw "Chrome native-host v2 state has an invalid schemaVersion or entries array: $statePath"
     }
     $matching = @($document.entries | Where-Object {
-      Test-ChromeNativeHostV2EntryCoreEqual $_ $expected
+      $entry = $_
+      @($acceptable | Where-Object { Test-ChromeNativeHostV2EntryCoreEqual $entry $_ }).Count -gt 0
     } | Select-Object -First 1)
     if ($matching.Count -eq 0) {
       throw "Chrome native-host v2 state has no current app-server entry: $statePath expected=$($expected.entryId)"
     }
     $verifiedPaths += $statePath
+    $matchedEntryIds += [string]$matching[0].entryId
   }
-  Write-Log "Chrome native-host v2 state verification ok: entry=$($expected.entryId) files=$($verifiedPaths.Count)"
+  $matchedSummary = @($matchedEntryIds | Sort-Object -Unique) -join ','
+  Write-Log "Chrome native-host v2 state verification ok: entry=$matchedSummary files=$($verifiedPaths.Count)"
 }
 
 function Test-OrdinalStringArrayEqual {

--- a/scripts/test-chrome-native-host-v2-state.ps1
+++ b/scripts/test-chrome-native-host-v2-state.ps1
@@ -134,11 +134,16 @@ ConvertTo-JsonFile (Join-Path $scriptsRoot 'extension-ids.json') ([ordered]@{
   }
 })
 
+$desktopManagedCodexCliPath = Join-Path $script:CodexHome 'plugins\.plugin-appserver\codex.exe'
+New-Item -ItemType Directory -Force -Path (Split-Path -Parent $desktopManagedCodexCliPath) | Out-Null
+Copy-Item -LiteralPath $codexCliPath -Destination $desktopManagedCodexCliPath -Force
+
 $runtimeInventory = [pscustomobject]@{
   CodexCliPath = $codexCliPath
   NodePath = $nodePath
   NodeReplPath = $nodeReplPath
   AllowedCodexCliPaths = @($codexCliPath)
+  DesktopManagedCodexCliPaths = @($desktopManagedCodexCliPath)
   AllowedCuaBinRoots = @($runtimeBin)
   PackageResourcesRoot = $packageResourcesRoot
 }
@@ -320,6 +325,62 @@ try {
       throw "V2 atomic replacement left transient files behind: $($transientFiles.FullName -join ',')"
     }
   }
+
+  $desktopManagedResource = Get-ChromeNativeHostV2ExpectedResource `
+    $chromeRoot $runtimeInventory $script:CodexHome -CodexCliPathOverride $desktopManagedCodexCliPath
+  if ([string]$desktopManagedResource.paths.codexCliPath -cne $desktopManagedCodexCliPath) {
+    throw 'The app-server path override did not reach the v2 entry paths'
+  }
+  if ([string]$desktopManagedResource.entryId -ceq [string]$expected.entryId) {
+    throw 'A different app-server path must produce a different v2 entryId'
+  }
+  if ([string]$desktopManagedResource.installId -cne [string]$expected.installId) {
+    throw 'The Desktop-managed app-server variant must keep the same v2 installId'
+  }
+  if (Test-ChromeNativeHostV2EntryCoreEqual $desktopManagedResource $expected) {
+    throw 'The Desktop-managed app-server variant must not core-equal the preferred entry'
+  }
+  $acceptableResources = @(Get-ChromeNativeHostV2AcceptableResources $chromeRoot $runtimeInventory $script:CodexHome)
+  if ($acceptableResources.Count -ne 2) {
+    throw "Acceptable v2 resources must cover the preferred and Desktop-managed app-server paths: count=$($acceptableResources.Count)"
+  }
+  if ([string]$acceptableResources[0].entryId -cne [string]$expected.entryId) {
+    throw 'The preferred v2 resource must stay first in the acceptable list'
+  }
+
+  # Desktop registers its own entry with the app-server copy it extracts under
+  # CODEX_HOME\plugins\.plugin-appserver. Verification must accept that entry
+  # instead of reporting a healthy install as missing, and repair must not keep
+  # trading the entry back and forth with Desktop.
+  foreach ($statePath in $statePaths) {
+    ConvertTo-JsonFile $statePath ([ordered]@{
+      schemaVersion = 2
+      entries = @($staleEntry, (Copy-JsonValue $desktopManagedResource))
+    })
+  }
+  Test-ChromeNativeHostV2State $chromeRoot $runtimeInventory $script:CodexHome
+  Update-ChromeNativeHostV2State $chromeRoot $runtimeInventory $script:CodexHome
+  foreach ($statePath in $statePaths) {
+    $desktopDocument = Get-Content -Raw -Encoding UTF8 -LiteralPath $statePath | ConvertFrom-Json
+    $keptEntries = @($desktopDocument.entries | Where-Object { $_.entryId -ceq $desktopManagedResource.entryId })
+    if ($keptEntries.Count -ne 1) {
+      throw "V2 repair replaced the Desktop-managed app-server entry: $statePath"
+    }
+    $preferredEntries = @($desktopDocument.entries | Where-Object { $_.entryId -ceq $expected.entryId })
+    if ($preferredEntries.Count -ne 0) {
+      throw "V2 repair added a duplicate entry for the same install: $statePath"
+    }
+  }
+  Test-ChromeNativeHostV2State $chromeRoot $runtimeInventory $script:CodexHome
+
+  foreach ($statePath in $statePaths) {
+    ConvertTo-JsonFile $statePath ([ordered]@{
+      schemaVersion = 2
+      entries = @($staleEntry)
+    })
+  }
+  Update-ChromeNativeHostV2State $chromeRoot $runtimeInventory $script:CodexHome
+  Test-ChromeNativeHostV2State $chromeRoot $runtimeInventory $script:CodexHome
 
   $brokenStatePath = $statePaths[0]
   $brokenDocument = Get-Content -Raw -Encoding UTF8 -LiteralPath $brokenStatePath | ConvertFrom-Json


### PR DESCRIPTION
Codex Desktop registers its own Chrome native-host v2 entry whose `codexCliPath` points at the app-server copy it extracts under `CODEX_HOME\plugins\.plugin-appserver`. That entry carries the same `installId` as the entry this script writes but a different `entryId`, so the two evict each other through `Test-ChromeNativeHostV2EntryReplacedBy`.

The visible symptom: after any Desktop launch, `-StrictVerifyOnly` fails on a perfectly healthy install with

```
Chrome native-host v2 state has no current app-server entry: <path> expected=codex-runtime-<hash>
```

and a repair run puts the script's entry back, which Desktop then evicts again on its next launch. The two keep trading the entry indefinitely.

## What changed

Verification now matches against a *set* of acceptable resources instead of a single expected one:

1. the preferred entry, pointing at the local runtime app-server copy (unchanged from before), and
2. when it exists and is byte-identical to the current app-server, the Desktop-managed `.plugin-appserver` copy.

Repair preserves whichever acceptable entry is already present, so a state file containing only Desktop's entry verifies and is left alone instead of being rewritten.

The Desktop-managed path is surfaced on the runtime inventory as `DesktopManagedCodexCliPaths` and is used only for entry matching. It is deliberately kept out of `AllowedCodexCliPaths` so it never becomes a trusted launch path.

Two smaller items ride along:

- `Get-CurrentCodexAppServerRuntimeInventory` gained defaulted parameters for the local runtime root and CODEX_HOME so the existing argument-less call sites are unaffected.
- The update log line reports the entry actually persisted rather than the preferred one, which previously made a preserve look like a replace.

## Testing

`scripts/test-chrome-native-host-v2-state.ps1` covers both directions:

- a state file holding only the Desktop-managed entry passes `Test-ChromeNativeHostV2State`;
- a repeated `Update-ChromeNativeHostV2State` over that state neither replaces that entry nor adds a duplicate for the same install;
- the pre-existing assertions (schema validation, stale-entry pruning, backup behaviour, idempotence) still pass.

Full run: `test-chrome-native-host-v2-state.ps1` exits 0. The rest of `scripts/test-*.ps1` is unchanged by this commit — 17 pass; the two that fail need prerequisites this change does not touch (`codex` on `PATH`, and an `@oai/sky 0.6.2` original helper transport that no longer ships).
