### PR TITLE
Stop pinning the reserved openai-bundled marketplace at an ignored source

### DIFF
--- a/scripts/install-computer-use-local.ps1
+++ b/scripts/install-computer-use-local.ps1
@@ -251,6 +251,36 @@ function Set-TomlTableKey {
   Write-Utf8NoBom $ConfigPath $content
 }
 
+function Get-TomlTableStringValue {
+  param(
+    [string]$ConfigPath,
+    [string]$Header,
+    [string]$Key
+  )
+
+  if (-not (Test-Path -LiteralPath $ConfigPath -PathType Leaf)) {
+    return ''
+  }
+  $content = [System.IO.File]::ReadAllText($ConfigPath, [System.Text.UTF8Encoding]::new($false))
+  $escapedHeader = [regex]::Escape($Header)
+  $tableMatch = [regex]::Match($content, "(?ms)^$escapedHeader\s*\r?\n(?<body>(?:(?!^\[).)*)")
+  if (-not $tableMatch.Success) {
+    return ''
+  }
+  $escapedKey = [regex]::Escape($Key)
+  $keyMatch = [regex]::Match(
+    $tableMatch.Groups['body'].Value,
+    "(?m)^\s*$escapedKey\s*=\s*(?:'(?<single>(?:[^']|'')*)'|""(?<double>(?:[^""\\]|\\.)*)"")\s*$"
+  )
+  if (-not $keyMatch.Success) {
+    return ''
+  }
+  if ($keyMatch.Groups['single'].Success) {
+    return $keyMatch.Groups['single'].Value -replace "''", "'"
+  }
+  return $keyMatch.Groups['double'].Value
+}
+
 function Remove-TomlTableKeys {
   param(
     [string]$ConfigPath,
@@ -1088,11 +1118,122 @@ function Get-ComputerUsePipeConfigState {
   return [pscustomobject]@{ Present = $true; Active = $active; PipePath = $pipePath }
 }
 
+function Test-CodexReservedMarketplaceSourceRestricted {
+  # Recent Codex CLI builds treat `openai-bundled` as a reserved marketplace name
+  # and only load it from the bundled marketplace root Desktop stages under
+  # CODEX_HOME\.tmp\bundled-marketplaces. Configuring the reserved name with any
+  # other local source makes the CLI drop the marketplace outright, which hides
+  # every bundled plugin instead of failing loudly.
+  #
+  # Probe the behaviour with a throwaway CODEX_HOME rather than sniffing versions.
+  # The control arm registers the same fixture under a non-reserved name, so a
+  # fixture the CLI rejects for unrelated reasons reports "unknown" instead of
+  # falsely reporting a restriction. Returns $true, $false, or $null (unknown).
+  $codexPath = ''
+  try {
+    $codexPath = Get-UsableCodexCliPath 'probe reserved marketplace sources'
+  } catch {
+    Write-Log "warning: cannot probe reserved marketplace sources: $($_.Exception.Message)"
+    return $null
+  }
+
+  $probeRoot = Join-Path $env:TEMP ('codex-marketplace-probe-' + [guid]::NewGuid().ToString('N'))
+  $previousCodexHome = $env:CODEX_HOME
+  $previousErrorActionPreference = $ErrorActionPreference
+  try {
+    $observed = @{}
+    foreach ($marketplaceName in @('codex-reserved-probe', 'openai-bundled')) {
+      $probeHome = Join-Path $probeRoot $marketplaceName
+      $mirrorRoot = Join-Path $probeHome 'marketplaces\mirror'
+      $pluginRoot = Join-Path $mirrorRoot 'plugins\computer-use'
+      $manifestRoot = Join-Path $mirrorRoot '.agents\plugins'
+      New-Item -ItemType Directory -Force -Path @($pluginRoot, $manifestRoot) | Out-Null
+      ConvertTo-JsonFile (Join-Path $pluginRoot 'plugin.json') ([ordered]@{
+        name = 'computer-use'
+        version = '0.0.0-probe'
+      })
+      ConvertTo-JsonFile (Join-Path $manifestRoot 'marketplace.json') ([ordered]@{
+        name = $marketplaceName
+        interface = [ordered]@{ displayName = 'Codex marketplace source probe' }
+        plugins = @(
+          [ordered]@{
+            name = 'computer-use'
+            source = [ordered]@{ source = 'local'; path = './plugins/computer-use' }
+            policy = [ordered]@{ installation = 'AVAILABLE'; authentication = 'ON_INSTALL' }
+          }
+        )
+      })
+      Write-Utf8NoBom (Join-Path $probeHome 'config.toml') (
+        "[marketplaces.$marketplaceName]`r`nsource_type = 'local'`r`nsource = '$mirrorRoot'`r`n"
+      )
+
+      $env:CODEX_HOME = $probeHome
+      # The CLI writes unrelated warnings to stderr (for example when it declines to
+      # create PATH aliases under a temporary CODEX_HOME). Under the script's default
+      # Stop preference those would surface as terminating errors and abort the probe,
+      # so relax the preference for the invocation only.
+      $ErrorActionPreference = 'Continue'
+      $output = @(& $codexPath plugin marketplace list 2>&1)
+      $ErrorActionPreference = $previousErrorActionPreference
+      # Match on the listing itself rather than the exit code: the resolved CLI can
+      # be a .cmd or .ps1 shim that does not set $LASTEXITCODE reliably.
+      $observed[$marketplaceName] =
+        @($output | Where-Object { "$_" -match "^\s*$([regex]::Escape($marketplaceName))\s" }).Count -gt 0
+    }
+
+    if (-not $observed['codex-reserved-probe']) {
+      Write-Log 'warning: reserved marketplace source probe was inconclusive; leaving the bundled marketplace pin unchanged'
+      return $null
+    }
+    return -not $observed['openai-bundled']
+  } catch {
+    Write-Log "warning: reserved marketplace source probe failed: $($_.Exception.Message)"
+    return $null
+  } finally {
+    $ErrorActionPreference = $previousErrorActionPreference
+    $env:CODEX_HOME = $previousCodexHome
+    Remove-Item -LiteralPath $probeRoot -Recurse -Force -ErrorAction SilentlyContinue
+  }
+}
+
+function Get-BundledMarketplaceConfigSource {
+  param(
+    [string]$MarketplaceRoot,
+    [string]$ConfigPath
+  )
+
+  $preferred = '\\?\' + $MarketplaceRoot
+  $codexHomeResolved = Resolve-OrCreateDirectory $CodexHome
+  $stagedRoot = Join-Path $codexHomeResolved '.tmp\bundled-marketplaces\openai-bundled'
+  if ($MarketplaceRoot -ieq $stagedRoot) {
+    return $preferred
+  }
+
+  $restricted = Test-CodexReservedMarketplaceSourceRestricted
+  if ($restricted -ne $true) {
+    return $preferred
+  }
+
+  if (Test-Path -LiteralPath $stagedRoot -PathType Container) {
+    Write-Log "reserved bundled marketplace source enforced; pinning the Desktop-staged root instead of $MarketplaceRoot"
+    return '\\?\' + $stagedRoot
+  }
+
+  $existing = Get-TomlTableStringValue $ConfigPath '[marketplaces.openai-bundled]' 'source'
+  if (-not [string]::IsNullOrWhiteSpace($existing)) {
+    Write-Log "reserved bundled marketplace source enforced and no staged root present; keeping the configured source"
+    return $existing
+  }
+
+  Write-Log 'warning: reserved bundled marketplace source enforced with no staged root or configured source; the CLI will ignore this marketplace'
+  return $preferred
+}
+
 function Update-CodexConfig {
   param([string]$MarketplaceRoot)
 
   $configPath = Join-Path $CodexHome 'config.toml'
-  $source = '\\?\' + $MarketplaceRoot
+  $source = Get-BundledMarketplaceConfigSource $MarketplaceRoot $configPath
   Set-TomlTable $configPath '[marketplaces.openai-bundled]' @{
     last_updated = [DateTime]::UtcNow.ToString('yyyy-MM-ddTHH:mm:ssZ')
     source = $source

--- a/scripts/test-bundled-marketplace-source.ps1
+++ b/scripts/test-bundled-marketplace-source.ps1
@@ -1,0 +1,135 @@
+﻿[CmdletBinding()]
+param(
+  [Parameter(Mandatory = $true)]
+  [string]$TemporaryRoot
+)
+
+$ErrorActionPreference = 'Stop'
+
+$scriptRoot = Split-Path -Parent $MyInvocation.MyCommand.Path
+$installer = Join-Path $scriptRoot 'install-computer-use-local.ps1'
+$parseErrors = $null
+$tokens = $null
+$installerAst = [System.Management.Automation.Language.Parser]::ParseFile(
+  $installer,
+  [ref]$tokens,
+  [ref]$parseErrors
+)
+if ($parseErrors.Count -gt 0) {
+  throw "Installer has PowerShell parse errors: $($parseErrors.Message -join '; ')"
+}
+foreach ($statement in $installerAst.EndBlock.Statements) {
+  if ($statement -is [System.Management.Automation.Language.FunctionDefinitionAst]) {
+    Invoke-Expression $statement.Extent.Text
+  }
+}
+
+# Loading only the function definitions skips the installer's script-level state,
+# which Backup-ConfigBeforeOverwrite needs before any config write.
+$script:ConfigBackupBeforeOverwrite = @{}
+
+$temp = [System.IO.Path]::GetFullPath($TemporaryRoot)
+New-Item -ItemType Directory -Force -Path $temp | Out-Null
+$fixtureRoot = Join-Path $temp ('bundled-marketplace-source-' + [guid]::NewGuid().ToString('N'))
+$script:CodexHome = Join-Path $fixtureRoot 'codex-home'
+New-Item -ItemType Directory -Force -Path $script:CodexHome | Out-Null
+
+$stableRoot = Join-Path $script:CodexHome 'marketplaces\openai-bundled-local'
+$stagedRoot = Join-Path $script:CodexHome '.tmp\bundled-marketplaces\openai-bundled'
+New-Item -ItemType Directory -Force -Path $stableRoot | Out-Null
+$configPath = Join-Path $script:CodexHome 'config.toml'
+
+# Get-TomlTableStringValue must read the value the installer itself writes,
+# including the literal backslashes and quote escaping used for Windows paths.
+Set-TomlTable $configPath '[marketplaces.openai-bundled]' @{
+  source = '\\?\C:\does\not\exist\o''brien'
+  source_type = 'local'
+}
+$readBack = Get-TomlTableStringValue $configPath '[marketplaces.openai-bundled]' 'source'
+if ($readBack -cne '\\?\C:\does\not\exist\o''brien') {
+  throw "Get-TomlTableStringValue did not round-trip a single-quoted Windows path: '$readBack'"
+}
+if ((Get-TomlTableStringValue $configPath '[marketplaces.openai-bundled]' 'missing_key') -cne '') {
+  throw 'Get-TomlTableStringValue must return an empty string for a missing key'
+}
+if ((Get-TomlTableStringValue $configPath '[marketplaces.absent]' 'source') -cne '') {
+  throw 'Get-TomlTableStringValue must return an empty string for a missing table'
+}
+Set-TomlTableKey $configPath '[marketplaces.double-quoted]' 'source' 'C:\quoted' 'test'
+[System.IO.File]::WriteAllText(
+  $configPath,
+  ([System.IO.File]::ReadAllText($configPath, [System.Text.UTF8Encoding]::new($false)) -replace
+    "(?m)^source = 'C:\\\\quoted'$", 'source = "C:\quoted"'),
+  [System.Text.UTF8Encoding]::new($false)
+)
+if ((Get-TomlTableStringValue $configPath '[marketplaces.double-quoted]' 'source') -cne 'C:\quoted') {
+  throw 'Get-TomlTableStringValue must also read double-quoted values'
+}
+
+function Set-ProbeResult {
+  param([object]$Value)
+
+  # Override at script scope: the installer's own definition lives there, so a
+  # global stub would never win function lookup.
+  $global:ProbeResult = $Value
+  $global:ProbeCalls = 0
+  Set-Item -Path 'function:script:Test-CodexReservedMarketplaceSourceRestricted' -Value {
+    $global:ProbeCalls++
+    return $global:ProbeResult
+  }
+}
+
+# The staged root is always allowed, so it must never pay for a probe.
+Set-ProbeResult $true
+$stagedSource = Get-BundledMarketplaceConfigSource $stagedRoot $configPath
+if ($stagedSource -cne ('\\?\' + $stagedRoot)) {
+  throw "The Desktop-staged root must be pinned verbatim: $stagedSource"
+}
+if ($global:ProbeCalls -ne 0) {
+  throw 'The Desktop-staged root must not trigger a reserved-source probe'
+}
+
+# Unrestricted CLI: keep pinning the stable mirror the installer maintains.
+Set-ProbeResult $false
+if ((Get-BundledMarketplaceConfigSource $stableRoot $configPath) -cne ('\\?\' + $stableRoot)) {
+  throw 'An unrestricted CLI must keep the stable mirror pin'
+}
+if ($global:ProbeCalls -ne 1) {
+  throw "The stable mirror must probe exactly once: $($global:ProbeCalls)"
+}
+
+# Inconclusive probe must not change behaviour either.
+Set-ProbeResult $null
+if ((Get-BundledMarketplaceConfigSource $stableRoot $configPath) -cne ('\\?\' + $stableRoot)) {
+  throw 'An inconclusive probe must keep the stable mirror pin'
+}
+
+# Restricted CLI with a staged root present: pin the staged root instead, so the
+# reserved `openai-bundled` name is not silently dropped by the CLI.
+Set-ProbeResult $true
+New-Item -ItemType Directory -Force -Path $stagedRoot | Out-Null
+if ((Get-BundledMarketplaceConfigSource $stableRoot $configPath) -cne ('\\?\' + $stagedRoot)) {
+  throw 'A restricted CLI must fall back to the Desktop-staged root'
+}
+
+# Restricted CLI with no staged root: keep whatever source is already configured
+# rather than overwriting a working pin with one the CLI will ignore.
+Remove-Item -LiteralPath $stagedRoot -Recurse -Force
+Set-TomlTable $configPath '[marketplaces.openai-bundled]' @{
+  source = '\\?\C:\already\working'
+  source_type = 'local'
+}
+Set-ProbeResult $true
+if ((Get-BundledMarketplaceConfigSource $stableRoot $configPath) -cne '\\?\C:\already\working') {
+  throw 'A restricted CLI with no staged root must preserve the configured source'
+}
+
+# Restricted CLI, no staged root and nothing configured: fall back to the stable
+# mirror and warn rather than writing an empty source.
+Remove-Item -LiteralPath $configPath -Force
+Set-ProbeResult $true
+if ((Get-BundledMarketplaceConfigSource $stableRoot $configPath) -cne ('\\?\' + $stableRoot)) {
+  throw 'A restricted CLI with nothing to fall back to must keep the stable mirror pin'
+}
+
+Write-Host "bundled marketplace source selection regression passed: $fixtureRoot"


### PR DESCRIPTION
Recent Codex CLI builds treat `openai-bundled` as a reserved marketplace name and only accept it from the bundled marketplace root Desktop stages under `CODEX_HOME\.tmp\bundled-marketplaces`. Configuring the reserved name with any other local source makes the CLI **drop the marketplace outright** instead of failing, so the stable-mirror pin this script writes hides every bundled plugin from the CLI.

With the mirror pinned:

```
> codex plugin marketplace list
MARKETPLACE             ROOT
openai-primary-runtime  ...\codex-primary-runtime\plugins\openai-primary-runtime
openai-curated          ...\.codex\.tmp\plugins
openai-curated-local    ...\.codex\marketplaces\openai-curated-local
                                        # openai-bundled is simply gone

> codex plugin list --marketplace openai-bundled --available --json
{ "installed": [], "available": [] }
```

Repointing the same config at the Desktop-staged root and changing nothing else:

```
> codex plugin marketplace list
...
openai-bundled          ...\.codex\.tmp\bundled-marketplaces\openai-bundled

> codex plugin list --marketplace openai-bundled --available --json
installed: browser, chrome, codex-app-tools, computer-use,
           deep-research, latex, sites, visualize
```

The reserved-name handling is visible in the CLI's own strings — `marketplace \`{}\` is reserved and cannot be loaded from this source` alongside a reserved-name list and the `tmp/bundled-marketplaces` allow-list literal.

## What changed

`Test-CodexReservedMarketplaceSourceRestricted` probes the behaviour instead of sniffing CLI versions. It builds a throwaway `CODEX_HOME` and asks the resolved CLI to list marketplaces twice: once with the fixture registered under a non-reserved name, once under `openai-bundled`. If the control arm is missing the probe reports *unknown* rather than a restriction, so a fixture rejected for unrelated reasons cannot cause a behaviour change. The probe also relaxes the error preference around the CLI call — the CLI writes unrelated warnings to stderr (for instance when it declines to create PATH aliases under a temporary `CODEX_HOME`), which under the script's `Stop` preference would abort the probe and silently disable the fix.

`Get-BundledMarketplaceConfigSource` picks the source:

| Situation | Pinned source |
| --- | --- |
| Root already is the staged root | that root, no probe |
| CLI unrestricted, or probe unknown | stable mirror (previous behaviour) |
| Restricted, staged root exists | staged root |
| Restricted, no staged root, source already configured | keep the configured source |
| Restricted, nothing to fall back to | stable mirror, with a warning |

The stable mirror is still synced, patched and verified exactly as before — only the config pin changes. The plugin cache Desktop actually loads (`plugins\cache\openai-bundled\...`) is untouched, so content patches are unaffected.

`Get-TomlTableStringValue` is added so the currently configured source can be read back before deciding.

## Testing

New `scripts/test-bundled-marketplace-source.ps1` covers the value reader (single-quoted Windows paths including an escaped quote, double-quoted values, missing key, missing table) and all five selection branches, including that the staged root never pays for a probe and that the unrestricted path probes exactly once.

The full `scripts/test-*.ps1` suite: 19 pass. Notably `test-bundled-plugin-scope.ps1` fails before this change (`Bundled plugin is missing from CLI output: sites`) and passes after it, which is the end-to-end proof. The one remaining failure, `test-computer-use-node-repl-context-patch.ps1`, needs an `@oai/sky 0.6.2` original helper transport that no longer ships and is unrelated to this change.
