### PR TITLE
[codex] continue after package-gated Computer Use preflight

### DIFF
--- a/SKILL.md
+++ b/SKILL.md
@@ -68,6 +68,8 @@ Before choosing the full MSIX repack path, identify whether the current failure 
 - Do not put Phone Remote Control into the default full repatch path unless the user asked for it. It is an opt-in workflow because it can require isolated remote-control OAuth, ASAR changes, a native app-server replacement binary, SQLite enrollment cleanup, and post-pairing API endpoint diagnosis.
 - If evidence is mixed, use the lowest-disruption path first: run read-only triage, then `scripts\install-computer-use-local.ps1 -VerifyOnly` for local plugin evidence, restart Codex Desktop only if needed, and escalate to MSIX only when logs or extracted ASAR checks still show a closed gate.
 
+The normal `scripts\repatch-codex-windows.ps1` preflight recognizes one package-gated Computer Use case: `installed app.asar does not preserve external NODE_REPL_TRUSTED_CODE_PATHS across Desktop config regeneration`. This means the installed app must be repatched before external D: marketplace/cache roots can survive Desktop config regeneration. For this exact message only, the wrapper records the fallback and continues into its MSIX dry run or install; unrelated Computer Use failures still stop the workflow. After installation, the wrapper runs the normal Computer Use refresh and strict verification. During a dry run, post-dry-run local verification is skipped only for this recognized case because the currently installed package is intentionally still unpatched.
+
 ## External Executor For Desktop-Restarting Repairs
 
 If a repair can stop, uninstall, reinstall, repackage, or relaunch Codex Desktop, do not run it from the Codex Desktop session being repaired. Use an external Windows PowerShell session, the VS Code Codex extension, or another agent environment that will survive the Desktop restart.
@@ -406,6 +408,7 @@ powershell -NoProfile -ExecutionPolicy Bypass -File "$env:USERPROFILE\.codex\ski
 - `-RegisterMarketplaceOnly`: only register `openai-curated-local`; do not patch Codex.
 - `-PatchScript <path>`: override the bundled patch script only when testing a newer patcher.
 - `-SkipComputerUse`: skip installing/verifying the local Computer Use compatibility plugin.
+- The wrapper may continue past Computer Use preflight only for the exact package-gated trusted-paths error documented above; use `-SkipComputerUse` only when intentionally separating local runtime repair from package patching.
 - `-VerifyAllBundledPluginsAvailable`: add an assertion that the stable `openai-bundled` descriptor names and versions exactly match the installed package and every entry appears with that version in structured CLI output as installed or available with an existing local source. The assertion never calls `plugin add`, but the main wrapper still performs its normal repair or DryRun behavior. For a fully read-only check, run `install-computer-use-local.ps1 -StrictVerifyOnly -VerifyAllBundledPluginsAvailable` directly.
 - `-InstallModelInstructionsFile`: optional; copy the bundled prompt asset to `$env:USERPROFILE\.codex\prompts\system-prompt.md` and set top-level `model_instructions_file` in `$env:USERPROFILE\.codex\config.toml`.
 - `-ModelInstructionsSource <path>`: optional source override for `-InstallModelInstructionsFile`; defaults to `assets\system-prompt.md`.

--- a/scripts/repatch-codex-windows.ps1
+++ b/scripts/repatch-codex-windows.ps1
@@ -27,6 +27,8 @@ if ([string]::IsNullOrWhiteSpace($PatchScript)) {
 $ComputerUseScript = Join-Path $ScriptRoot 'install-computer-use-local.ps1'
 $ModelInstructionsScript = Join-Path $ScriptRoot 'install-model-instructions-file.ps1'
 $script:ConfigBackupBeforeOverwrite = @{}
+$script:ComputerUsePackageGateFallback = $false
+$ComputerUsePackageGateFallbackMessage = 'installed app.asar does not preserve external NODE_REPL_TRUSTED_CODE_PATHS across Desktop config regeneration'
 
 function Write-Log {
   param([string]$Message)
@@ -261,7 +263,8 @@ function Invoke-ComputerUseInstaller {
   param(
     [string]$Stage,
     [switch]$VerifyOnly,
-    [switch]$VerifyAllBundledPluginsAvailable
+    [switch]$VerifyAllBundledPluginsAvailable,
+    [switch]$AllowPackageGateFallback
   )
 
   if (-not (Test-Path -LiteralPath $ComputerUseScript)) {
@@ -279,9 +282,39 @@ function Invoke-ComputerUseInstaller {
   }
 
   Write-Log "Computer Use ${mode}: $Stage"
-  Invoke-Checked 'powershell' $args "Computer Use $mode failed"
+  if ($AllowPackageGateFallback) {
+    $previousErrorAction = $ErrorActionPreference
+    try {
+      $ErrorActionPreference = 'Continue'
+      $captured = @(
+        & powershell @args 2>&1 | ForEach-Object {
+          $line = [string]$_
+          Write-Host $line
+          $line
+        }
+      )
+    } finally {
+      $ErrorActionPreference = $previousErrorAction
+    }
+    $exitCode = $LASTEXITCODE
+    if ($exitCode -ne 0) {
+      $output = (($captured -join "`n") -replace '\s+', '')
+      $needle = ($ComputerUsePackageGateFallbackMessage -replace '\s+', '')
+      if ($output.IndexOf($needle, [StringComparison]::OrdinalIgnoreCase) -ge 0) {
+        $script:ComputerUsePackageGateFallback = $true
+        Write-Log "Computer Use preflight hit the package-gated trusted-paths check; continuing to MSIX patch: $ComputerUsePackageGateFallbackMessage"
+        $env:CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE = '1'
+        Enable-ComputerUseFeature
+        return $false
+      }
+      throw "Computer Use $mode failed (exit code $exitCode)"
+    }
+  } else {
+    Invoke-Checked 'powershell' $args "Computer Use $mode failed"
+  }
   $env:CODEX_ELECTRON_ENABLE_WINDOWS_COMPUTER_USE = '1'
   Enable-ComputerUseFeature
+  return $true
 }
 
 function Enable-ComputerUseFeature {
@@ -436,9 +469,9 @@ if (-not $SkipMarketplace) {
 
 if (-not $SkipComputerUse) {
   if ($DryRun) {
-    Invoke-ComputerUseInstaller -Stage 'preflight before MSIX dry run' -VerifyOnly -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable
+    Invoke-ComputerUseInstaller -Stage 'preflight before MSIX dry run' -VerifyOnly -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable -AllowPackageGateFallback
   } else {
-    Invoke-ComputerUseInstaller -Stage 'preflight before MSIX patch' -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable
+    Invoke-ComputerUseInstaller -Stage 'preflight before MSIX patch' -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable -AllowPackageGateFallback
   }
 }
 
@@ -520,7 +553,11 @@ for ($patchAttempt = 1; $patchAttempt -le $maxPatchAttempts; $patchAttempt++) {
 
   if (-not $SkipComputerUse) {
     if ($DryRun) {
-      Invoke-ComputerUseInstaller -Stage 'post-dry-run final verification' -VerifyOnly -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable
+      if ($script:ComputerUsePackageGateFallback) {
+        Write-Log 'post-dry-run Computer Use verification skipped because the installed package is expected to fail the same package-gated trusted-paths check until MSIX installation'
+      } else {
+        Invoke-ComputerUseInstaller -Stage 'post-dry-run final verification' -VerifyOnly -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable
+      }
     } else {
       Invoke-ComputerUseInstaller -Stage 'post-patch refresh after Codex startup' -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable
       Invoke-ComputerUseInstaller -Stage 'post-patch final verification' -VerifyOnly -VerifyAllBundledPluginsAvailable:$VerifyAllBundledPluginsAvailable


### PR DESCRIPTION
## What changed

- Recognize the exact installed-app trusted-paths gate that requires an MSIX repatch before external D: marketplace/cache roots can survive Desktop config regeneration.
- Continue to the MSIX dry run or install only for that exact message.
- Keep unrelated Computer Use preflight failures fatal and retain post-install strict verification.

## Validation

- PowerShell AST parse passed.
- `git diff --check` passed.
- Isolated PowerShell 5.1 fixture passed with the long stderr line wrapped across multiple output records.
- No phone remote-control code or workstation artifacts are included.