### PR TITLE
feat: retain sky 0.6.17 4250FF66, 4319D3A2 and D967386B helper profiles

### DIFF
--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -285,6 +285,84 @@ $PatchProfiles = @(
     )
   },
   [ordered]@{
+    Name = '@oai/sky 0.6.17 helper 4319D3A2 / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.818.5229.0'
+    SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
+    OriginalSha256 = '4319D3A23F6B21370205425203BD46E76E7F3BB7EA5AC263851DCC5B8727AAE5'
+    PatchedSha256 = '338D32A33BB7C034FEBCA79D23EF2337BCCE1CC9741784C1C11CE64F3A508368'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x00047E01
+        OriginalHex = '4889c34189d6eb50'
+        PatchedHex = 'e980000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004CF86
+        OriginalHex = '0f85f5340000'
+        PatchedHex = '0f85d8340000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004CF97
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x001486AF
+        OriginalHex = ('cc' + (('00' * 174) -join ''))
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15081200004885c074104889c1ff154211000031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15020f0000488b4c2428e80348f0ffff15fa0e0000488b4c2428488b01ff501031c04883c438c3c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0014B128
+        OriginalHex = '43db044001000000'
+        PatchedHex = 'af92144001000000'
+      }
+    )
+  },
+  [ordered]@{
+    Name = '@oai/sky 0.6.17 helper 4250FF66 / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.818.4152.0'
+    SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
+    OriginalSha256 = '4250FF66B8EE598931DBE782E1CC76133FBE7650CCE225C4FC232155F7054350'
+    PatchedSha256 = 'F4408E2C59F037D8B96ADAF3DE48846DB2921A9F007BC3CCAE34C1407A609ACC'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x00047E01
+        OriginalHex = '4889c34189d6eb50'
+        PatchedHex = 'e980000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004CF86
+        OriginalHex = '0f85f5340000'
+        PatchedHex = '0f85d8340000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004CF97
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x001486AF
+        OriginalHex = ('cc' + (('00' * 174) -join ''))
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15081200004885c074104889c1ff154211000031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15020f0000488b4c2428e80348f0ffff15fa0e0000488b4c2428488b01ff501031c04883c438c3c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0014B128
+        OriginalHex = '43db044001000000'
+        PatchedHex = 'af92144001000000'
+      }
+    )
+  },
+  [ordered]@{
     Name = '@oai/sky 0.6.11 helper 7A95D14E / Windows 10 screenshot backend'
     ValidatedDesktopVersion = '26.810.7004.0'
     SkyVersion = '0.6.11'

--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -285,6 +285,45 @@ $PatchProfiles = @(
     )
   },
   [ordered]@{
+    Name = '@oai/sky 0.6.17 helper D967386B / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.818.8289.0'
+    SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
+    OriginalSha256 = 'D967386B8943355017B7CFC1044A6F39AF41A38A3731088C4191123CE7F86018'
+    PatchedSha256 = 'B43B12A8A23BE7CED3CCB64C56CC6885A483DBD482891116AB78C35CC3ACFB30'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x00047E01
+        OriginalHex = '4889c34189d6eb50'
+        PatchedHex = 'e980000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004CF86
+        OriginalHex = '0f85f5340000'
+        PatchedHex = '0f85d8340000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004CF97
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x001486AF
+        OriginalHex = ('cc' + (('00' * 174) -join ''))
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15081200004885c074104889c1ff154211000031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15020f0000488b4c2428e80348f0ffff15fa0e0000488b4c2428488b01ff501031c04883c438c3c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0014B128
+        OriginalHex = '43db044001000000'
+        PatchedHex = 'af92144001000000'
+      }
+    )
+  },
+  [ordered]@{
     Name = '@oai/sky 0.6.17 helper 4319D3A2 / Windows 10 screenshot backend'
     ValidatedDesktopVersion = '26.818.5229.0'
     SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2')]
+  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -53,6 +53,11 @@ $Profiles = @{
     SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
     OriginalHash = '4319D3A23F6B21370205425203BD46E76E7F3BB7EA5AC263851DCC5B8727AAE5'
     PatchedHash = '338D32A33BB7C034FEBCA79D23EF2337BCCE1CC9741784C1C11CE64F3A508368'
+  }
+  '0.6.17-D967386B' = [ordered]@{
+    SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
+    OriginalHash = 'D967386B8943355017B7CFC1044A6F39AF41A38A3731088C4191123CE7F86018'
+    PatchedHash = 'B43B12A8A23BE7CED3CCB64C56CC6885A483DBD482891116AB78C35CC3ACFB30'
   }
 }
 $ProfileLabel = $SkyVersion

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486')]
+  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -43,6 +43,16 @@ $Profiles = @{
     SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
     OriginalHash = 'DB8F4486D527C91B80266FAF77FDC38266B1D3960EFBBA35D0A6AAB4CAAF6AEE'
     PatchedHash = '6495168DC16A35CDC33230E6512D64E660B56D13E99FE239426D228B9F86E157'
+  }
+  '0.6.17-4250FF66' = [ordered]@{
+    SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
+    OriginalHash = '4250FF66B8EE598931DBE782E1CC76133FBE7650CCE225C4FC232155F7054350'
+    PatchedHash = 'F4408E2C59F037D8B96ADAF3DE48846DB2921A9F007BC3CCAE34C1407A609ACC'
+  }
+  '0.6.17-4319D3A2' = [ordered]@{
+    SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
+    OriginalHash = '4319D3A23F6B21370205425203BD46E76E7F3BB7EA5AC263851DCC5B8727AAE5'
+    PatchedHash = '338D32A33BB7C034FEBCA79D23EF2337BCCE1CC9741784C1C11CE64F3A508368'
   }
 }
 $ProfileLabel = $SkyVersion


### PR DESCRIPTION
Desktop keeps shipping new `codex-computer-use.exe` binaries under the same
`@oai/sky` version string `0.6.17-202608171537-pr-1300023-7efba775c041`. All four
0.6.17 binaries seen so far are byte-identical in every patch region, so the Win10
screenshot patch applies unchanged; only the hash pair differs.

This PR retains three of them:

| profile | shipped with |
| --- | --- |
| `0.6.17-4250FF66` | Desktop 26.818.4152.0 |
| `0.6.17-4319D3A2` | Desktop 26.818.5229.0 |
| `0.6.17-D967386B` | Desktop 26.818.8289.0 |

Each was cleared before adding by a whole-file byte diff against an already
validated baseline: below the highest patch region (`0x0014B128`+8) the only
difference is the PE checksum at `0x158`-`0x159`, and all five patch regions
compare `identical=True`. For D967386B the import references inside the
175-byte `mta-worker-wrapper` blob were additionally resolved and shown to
target the same imports (`CreateThread`, `CloseHandle`, `RoInitialize`,
`RoUninitialize`) and the same `call rel32` destination, with byte-identical
section tables.

Verification:

- `test-computer-use-helper-win10-patch.ps1` passes for all three new labels
  (offline apply + patched-hash match + rollback to the original hash)
- the D967386B profile is running on a live 26.818.8289.0 install: patched
  helper hash matches `PatchedSha256`, and a real animated-window regression
  produced 28/28 unique JPEG frames with zero `SetIsBorderRequired` /
  `E_NOINTERFACE` / `0x80004002` occurrences
- PowerShell parse: 0 errors in both files

Note on the earlier commit message in this branch: `62cc4ff` says "All three
0.6.17 binaries" while listing four hashes. It should read "All four"; the
pushed commit is left as-is and this description carries the correction. With
D967386B the count is five.