### PR TITLE
Support sky 0.6.24 gate shapes and four Windows 10 helper profiles

### DIFF
--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -608,13 +608,15 @@ $PatchProfiles = @(
     )
   },
   # Desktop 26.825.5331.0 ships a fourth binary reporting the same 0.6.24 sky
-  # version string. It is the 4DB7B670 helper re-signed: all ten section headers
-  # and bodies are byte-identical, and the 1964 differing whole-file bytes are
-  # fully accounted for by the optional-header checksum (2 bytes at 0xD8..0xDB,
-  # 0x00173283 -> 0x0017A30C) plus the Authenticode certificate table (1962
-  # bytes at 0x0016D000..0x00170D2F); zero bytes differ outside those two areas.
-  # All five regions verified present at the same offsets with the same original
-  # bytes, so they carry over unchanged and only the whole-file hashes move.
+  # version string. It is the 4DB7B670 helper re-signed: the 400-byte section
+  # table is byte-identical, all nine sections that carry raw data have identical
+  # bodies (.bss has none), and even the COFF timestamp is unchanged. The 1964
+  # differing whole-file bytes are fully accounted for by the optional-header
+  # checksum (2 bytes at 0xD8..0xD9, 0x00173283 -> 0x0017A30C) plus the
+  # Authenticode certificate table (1962 bytes, last difference at 0x00170D2C);
+  # zero bytes differ outside those two areas. All five regions verified present
+  # at the same offsets with the same original bytes, so they carry over
+  # unchanged and only the whole-file hashes move.
   [ordered]@{
     Name = '@oai/sky 0.6.24 helper 9BAB6E1B / Windows 10 screenshot backend'
     ValidatedDesktopVersion = '26.825.5331.0'

--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -478,6 +478,88 @@ $PatchProfiles = @(
         PatchedHex = '8f92144001000000'
       }
     )
+  },
+  [ordered]@{
+    Name = '@oai/sky 0.6.23 helper 8423CA8C / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.820.10647.0'
+    SkyVersion = '0.6.23-202608251207-pr-1350514-1bc5ee2d44ce'
+    OriginalSha256 = '8423CA8C5B75BD2ADCDC0E0BB0242A8F5422D16E12505753E84728D4A112458F'
+    PatchedSha256 = 'E7C020B3451F6F2EF300D725A6B2AFC45A223A07C87D6D053B93BF3B28F0B661'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D71A
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004133E
+        OriginalHex = '0f8543310000'
+        PatchedHex = '0f8525310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004134F
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x0011EF20
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff1507d404004885c074104889c1ff15c1d3040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff1501d30400488b4c2428e85823f2ffff15f9d20400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x00124C10
+        OriginalHex = '091f044001000000'
+        PatchedHex = '20fb114001000000'
+      }
+    )
+  },
+  # 0.6.24's helper is the 0.6.23 binary re-signed: every section body is
+  # byte-identical and only the COFF timestamp (0x88..0x8A) and the optional
+  # header checksum (0xD8..0xD9) differ, so all five regions carry over at the
+  # same offsets with the same bytes. Only the whole-file hashes change.
+  [ordered]@{
+    Name = '@oai/sky 0.6.24 helper DE3696C0 / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.825.3734.0'
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalSha256 = 'DE3696C0E35CB4A00A77F284779E03FBED6B46D9EE00CA261D2B467064A3D149'
+    PatchedSha256 = '1AB5261A714BDD10BCE038319A4668E366B679691A746B569731ED994FAC80E3'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D71A
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004133E
+        OriginalHex = '0f8543310000'
+        PatchedHex = '0f8525310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004134F
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x0011EF20
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff1507d404004885c074104889c1ff15c1d3040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff1501d30400488b4c2428e85823f2ffff15f9d20400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x00124C10
+        OriginalHex = '091f044001000000'
+        PatchedHex = '20fb114001000000'
+      }
+    )
   }
 )
 

--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -606,6 +606,53 @@ $PatchProfiles = @(
         PatchedHex = '20fb114001000000'
       }
     )
+  },
+  # Desktop 26.825.5331.0 ships a fourth binary reporting the same 0.6.24 sky
+  # version string. It is the 4DB7B670 helper re-signed: all ten section headers
+  # and bodies are byte-identical, and the 1964 differing whole-file bytes are
+  # fully accounted for by the optional-header checksum (2 bytes at 0xD8..0xDB,
+  # 0x00173283 -> 0x0017A30C) plus the Authenticode certificate table (1962
+  # bytes at 0x0016D000..0x00170D2F); zero bytes differ outside those two areas.
+  # All five regions verified present at the same offsets with the same original
+  # bytes, so they carry over unchanged and only the whole-file hashes move.
+  [ordered]@{
+    Name = '@oai/sky 0.6.24 helper 9BAB6E1B / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.825.5331.0'
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalSha256 = '9BAB6E1B59D31D97530F2F6681DAEF76E39C7AD0836147C6E0B55A9B47A33EBF'
+    PatchedSha256 = 'B86B1FCB9EBD7184526AF49D40333FDA02F774FA62E0E9A3528BA5F87EB68AB7'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D71A
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004133E
+        OriginalHex = '0f8543310000'
+        PatchedHex = '0f8525310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004134F
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x0011EF20
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff1507d404004885c074104889c1ff15c1d3040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff1501d30400488b4c2428e85823f2ffff15f9d20400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x00124C10
+        OriginalHex = '091f044001000000'
+        PatchedHex = '20fb114001000000'
+      }
+    )
   }
 )
 

--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -560,6 +560,52 @@ $PatchProfiles = @(
         PatchedHex = '20fb114001000000'
       }
     )
+  },
+  # Desktop 26.825.4187.0 ships a third binary reporting the same 0.6.24 sky
+  # version string. It is the DE3696C0 helper re-signed: all nine section
+  # bodies are byte-identical and the whole file differs in only two bytes,
+  # the optional-header checksum at 0xD8..0xD9. The five regions therefore
+  # carry over at the same offsets with the same bytes; only the whole-file
+  # hashes change. This is why a profile is keyed on the complete helper
+  # SHA-256 and never on the reported version.
+  [ordered]@{
+    Name = '@oai/sky 0.6.24 helper 4DB7B670 / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.825.4187.0'
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalSha256 = '4DB7B6709F5B6DB2AE6DF60A1BDE026CF8A3582EEB616AF6B6529150E11B5CE1'
+    PatchedSha256 = '986AA8DC4F6B2DC0A9551617120AF82915EC42C9F745BDE5F474EEB44A6ACCBD'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D71A
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004133E
+        OriginalHex = '0f8543310000'
+        PatchedHex = '0f8525310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004134F
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x0011EF20
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff1507d404004885c074104889c1ff15c1d3040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff1501d30400488b4c2428e85823f2ffff15f9d20400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x00124C10
+        OriginalHex = '091f044001000000'
+        PatchedHex = '20fb114001000000'
+      }
+    )
   }
 )
 

--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -794,6 +794,14 @@ const visibilityPatterns = [
     modelGroup: 2,
     isReturn: true,
   },
+  {
+    // 0.6.24+ inserts a `hasConfiguredModelCatalog&&!model.hidden||` disjunct
+    // ahead of the useHiddenModels ternary and wraps that ternary in one more
+    // paren layer.
+    re: /return ([$A-Za-z_][$\w]*)\?\.has\(([$A-Za-z_][$\w]*)\.model\)===!0\|\|\2\.model!==`codex-auto-review`&&\(([$A-Za-z_][$\w]*)&&!\2\.hidden\|\|\(([$A-Za-z_][$\w]*)&&!([$A-Za-z_][$\w]*)&&([$A-Za-z_][$\w]*)!==`amazonBedrock`\?([$A-Za-z_][$\w]*)\.has\(\2\.model\):!\2\.hidden\)\)\}/,
+    modelGroup: 2,
+    isReturn: true,
+  },
 ];
 const target = visibilityPatterns
   .map(({ re, modelGroup, isReturn }) => ({ match: text.match(re), modelGroup, isReturn }))
@@ -894,14 +902,19 @@ const [, mutationFn, mutationScope, enabled, snapshot, userSettingsQuery, previo
 const mutationReplacement = `async function ${mutationFn}(${mutationScope},${enabled}){let ${snapshot}=${mutationScope}.query.snapshot(${userSettingsQuery}),${previous}=${snapshot}.getData();${snapshot}.setData(${cached}=>${cached}==null?${cached}:{...${cached},ultraEffortEnabled:${enabled}});if(${previous}?.ultraEffortLocalFallback===!0){try{await ${writeConfig}(${mutationScope},${settings}.showUltraInModelPickerSlider,${enabled});return}catch(codexUltraLocalError){throw ${snapshot}.setData(${previous}),codexUltraLocalError}}try{await ${mutationScope}.get(${client}).setUltraEffortEnabled(${enabled}),await Promise.all([${snapshot}.invalidate(),${mutationScope}.query.snapshot(${tppQuery}).invalidate()])}catch(codexUltraRemoteError){throw ${snapshot}.setData(${previous}),codexUltraRemoteError}}`;
 let next = text.replace(mutationRe, mutationReplacement);
 
-const queryRe = /queryFn:async\(\)=>\{let ([$A-Za-z_][$\w]*)=([$A-Za-z_][$\w]*)\.parse\(await ([$A-Za-z_][$\w]*)\.get\(([$A-Za-z_][$\w]*)\)\.userSettings\(\)\);return\{((?:eligibleAnnouncements:[^,]+,)?)lockdownModeEnabled:\1\.settings\?\.lockdown_mode_enabled===!0,ultraEffortEnabled:\1\.settings\?\.model_picker_persists_ultra_effort===!0\}\}/;
+// 0.6.24+ moves the conversation client behind a dynamic import inside the
+// queryFn and adds keys (chatTheme) to the returned object, so tolerate an
+// arbitrary prologue and any number of extra keys. The whole success body is
+// captured verbatim and re-emitted inside the try, which keeps every returned
+// field intact instead of rebuilding the object from named groups.
+const queryRe = /queryFn:async\(\)=>\{(let(?:\{[\s\S]{0,800}?import\.meta\.url\),|\s)([$A-Za-z_][$\w]*)=([$A-Za-z_][$\w]*)\.parse\(await ([$A-Za-z_][$\w]*)\.get\(([$A-Za-z_][$\w]*)\)\.userSettings\(\)\);return\{(?:[$A-Za-z_][$\w]*:[^,]+,)*?lockdownModeEnabled:\2\.settings\?\.lockdown_mode_enabled===!0,ultraEffortEnabled:\2\.settings\?\.model_picker_persists_ultra_effort===!0\})\}/;
 const queryMatch = next.match(queryRe);
 if (!queryMatch) {
   process.stderr.write('ultra-user-settings-query-target-not-found\n');
   process.exit(2);
 }
-const [, parsed, schema, queryScope, queryClient, eligiblePrefix] = queryMatch;
-const queryReplacement = `queryFn:async()=>{try{let ${parsed}=${schema}.parse(await ${queryScope}.get(${queryClient}).userSettings());return{${eligiblePrefix}lockdownModeEnabled:${parsed}.settings?.lockdown_mode_enabled===!0,ultraEffortEnabled:${parsed}.settings?.model_picker_persists_ultra_effort===!0}}catch{return{lockdownModeEnabled:!1,ultraEffortEnabled:await ${readConfig}(${settings}.showUltraInModelPickerSlider).catch(()=>!1)===!0,ultraEffortLocalFallback:!0/*${marker}*/}}}`;
+const querySuccessBody = queryMatch[1];
+const queryReplacement = `queryFn:async()=>{try{${querySuccessBody}}catch{return{lockdownModeEnabled:!1,ultraEffortEnabled:await ${readConfig}(${settings}.showUltraInModelPickerSlider).catch(()=>!1)===!0,ultraEffortLocalFallback:!0/*${marker}*/}}}`;
 next = next.replace(queryRe, queryReplacement);
 
 const migrationKey = 'queryKey:[`chatgpt-ultra-effort-migration`]';
@@ -1372,11 +1385,31 @@ function patchSidebarAvailability(file) {
     /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\.isCapable,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`410262010`\)/,
     '$1=!0,$5=($6(`410262010`),!0)/*CODEX_BROWSER_IN_APP_GATES_V2*/'
   );
+  // 0.6.24+ drops the `410262010` statsig literal entirely and prefixes the
+  // capability entry with accessPolicy, so anchor on the capability table
+  // instead. Strip every requirement key rather than just configFeatures: the
+  // capability atom short-circuits to isCapable:!0 only when the whole
+  // requirement list comes out empty.
+  const modernCapabilityPattern = /("browser\.in-app":\{)(?:accessPolicy:`[\w-]+`,|configFeatures:\[\{key:`in_app_browser`,host:`default`\}\],)+/;
+  const modernCapabilityPatched = /"browser\.in-app":\{supportedClients:\[`electron`\]\}/.test(before);
+  const beforeModernCapability = after;
+  after = after.replace(modernCapabilityPattern, '$1');
+  if (after === beforeModernCapability && !modernCapabilityPatched) {
+    after = after.replace(
+      // The capability-read helper is renamed by the minifier on every release,
+      // so match any identifier rather than a fixed one.
+      /(name:`browser\.in-app`[\s\S]{0,1800}?)(let|var) ([A-Za-z_$][\w$]*)=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,[A-Za-z_$][\w$]*\)\.isCapable,/g,
+      '$1$2 $3=!0,'
+    );
+  }
+  const modernSidebarPatched = modernCapabilityPatched ||
+    /name:`browser\.in-app`[\s\S]{0,1800}?(?:let|var) [A-Za-z_$][\w$]*=!0,/.test(before);
   if (after === before &&
        !before.includes('a=t(n,()=>!0)') &&
        !/`in_app_browser`,[A-Za-z_$][\w$]*=[A-Za-z_$][\w$]*\([A-Za-z_$][\w$]*,\(\)=>!0\)/.test(before) &&
        !/([A-Za-z_$][\w$]*)=!0,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`410262010`\)/.test(before) &&
-       !before.includes('CODEX_BROWSER_IN_APP_GATES_V2')) {
+       !before.includes('CODEX_BROWSER_IN_APP_GATES_V2') &&
+       !modernSidebarPatched) {
     process.stderr.write('browser-sidebar-availability-patch-target-not-found\n');
     process.exit(2);
   }
@@ -1591,7 +1624,8 @@ function Test-CustomModelVisibilityExpression {
     'if\([$A-Za-z_][$\w]*\?[$A-Za-z_][$\w]*\.has\((?<model>[$A-Za-z_][$\w]*)\.model\):!\k<model>\.hidden\)\{',
     'if\([$A-Za-z_][$\w]*\?\.has\((?<model>[$A-Za-z_][$\w]*)\.model\)===!0\|\|\([$A-Za-z_][$\w]*\?[$A-Za-z_][$\w]*\.has\(\k<model>\.model\):!\k<model>\.hidden\)\)\{',
     '\?\.has\(\w+\.model\)===!0\|\|\(\w+(?:&&\w+!==`amazonBedrock`)?\?\w+\.has\(\w+\.model\):!\w+\.hidden\)',
-    '\?\.has\((?<model>[$A-Za-z_][$\w]*)\.model\)===!0\|\|\k<model>\.model!==`codex-auto-review`&&\((?<showHidden>[$A-Za-z_][$\w]*)&&!(?<customProvider>[$A-Za-z_][$\w]*)&&(?<authMethod>[$A-Za-z_][$\w]*)!==`amazonBedrock`\?(?<availableModels>[$A-Za-z_][$\w]*)\.has\(\k<model>\.model\):!\k<model>\.hidden\)'
+    '\?\.has\((?<model>[$A-Za-z_][$\w]*)\.model\)===!0\|\|\k<model>\.model!==`codex-auto-review`&&\((?<showHidden>[$A-Za-z_][$\w]*)&&!(?<customProvider>[$A-Za-z_][$\w]*)&&(?<authMethod>[$A-Za-z_][$\w]*)!==`amazonBedrock`\?(?<availableModels>[$A-Za-z_][$\w]*)\.has\(\k<model>\.model\):!\k<model>\.hidden\)',
+    '\?\.has\((?<model>[$A-Za-z_][$\w]*)\.model\)===!0\|\|\k<model>\.model!==`codex-auto-review`&&\((?<hasCatalog>[$A-Za-z_][$\w]*)&&!\k<model>\.hidden\|\|\((?<showHidden>[$A-Za-z_][$\w]*)&&!(?<customProvider>[$A-Za-z_][$\w]*)&&(?<authMethod>[$A-Za-z_][$\w]*)!==`amazonBedrock`\?(?<availableModels>[$A-Za-z_][$\w]*)\.has\(\k<model>\.model\):!\k<model>\.hidden\)\)'
   )
   foreach ($pattern in $patterns) {
     if ($Text -match $pattern) {

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,12 +3,22 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670')]
+  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670')]
   [string]$SkyVersion = '0.6.16'
 )
 
 $ErrorActionPreference = 'Stop'
 $Profiles = @{
+  '0.4.20-F2B2F56F' = [ordered]@{
+    SkyVersion = '0.4.20'
+    OriginalHash = 'F2B2F56FCD1699B0FA32DEC3214A56A1D36B937A2ECF58CC822AB4A904551E03'
+    PatchedHash = '71A13CBC4BB333F0707D2311C99DBA54D8B24D1BBB9F7CE25C3B9386577FFDDA'
+  }
+  '0.5.2-2C4CAC16' = [ordered]@{
+    SkyVersion = '0.5.2'
+    OriginalHash = '2C4CAC168200520C2752058177EA9FE7D1CCF9A26B7287DDDFF669D41CA9AF16'
+    PatchedHash = 'D816B14A80370697380BA702863DA9528AA5B73ED34C2B189ACE2BF9E103BEFF'
+  }
   '0.6.6' = [ordered]@{
     SkyVersion = '0.6.6'
     OriginalHash = 'BE488E66C38E12FA46850EE48C1F5E44ECDB0A3A64042E064E3A1A1DA286AC42'
@@ -269,7 +279,7 @@ try {
   }
 
   $unknownBytes = [IO.File]::ReadAllBytes($testHelper)
-  $unknownBytes[0x47E01] = $unknownBytes[0x47E01] -bxor 1
+  $unknownBytes[$unknownBytes.Length - 1] = $unknownBytes[$unknownBytes.Length - 1] -bxor 1
   [IO.File]::WriteAllBytes($testHelper, $unknownBytes)
   $unknown = Get-Status $testHelper $codexHome
   Assert-Equal $unknown.State 'unsupported' 'unknown hash state mismatch'

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670')]
+  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670', '0.6.24-9BAB6E1B')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -84,6 +84,12 @@ $Profiles = @{
     SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
     OriginalHash = '4DB7B6709F5B6DB2AE6DF60A1BDE026CF8A3582EEB616AF6B6529150E11B5CE1'
     PatchedHash = '986AA8DC4F6B2DC0A9551617120AF82915EC42C9F745BDE5F474EEB44A6ACCBD'
+  }
+  # Third binary on the same sky version string, shipped by Desktop 26.825.5331.0.
+  '0.6.24-9BAB6E1B' = [ordered]@{
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalHash = '9BAB6E1B59D31D97530F2F6681DAEF76E39C7AD0836147C6E0B55A9B47A33EBF'
+    PatchedHash = 'B86B1FCB9EBD7184526AF49D40333FDA02F774FA62E0E9A3528BA5F87EB68AB7'
   }
 }
 $ProfileLabel = $SkyVersion

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B')]
+  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -58,6 +58,16 @@ $Profiles = @{
     SkyVersion = '0.6.17-202608171537-pr-1300023-7efba775c041'
     OriginalHash = 'D967386B8943355017B7CFC1044A6F39AF41A38A3731088C4191123CE7F86018'
     PatchedHash = 'B43B12A8A23BE7CED3CCB64C56CC6885A483DBD482891116AB78C35CC3ACFB30'
+  }
+  '0.6.23-8423CA8C' = [ordered]@{
+    SkyVersion = '0.6.23-202608251207-pr-1350514-1bc5ee2d44ce'
+    OriginalHash = '8423CA8C5B75BD2ADCDC0E0BB0242A8F5422D16E12505753E84728D4A112458F'
+    PatchedHash = 'E7C020B3451F6F2EF300D725A6B2AFC45A223A07C87D6D053B93BF3B28F0B661'
+  }
+  '0.6.24-DE3696C0' = [ordered]@{
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalHash = 'DE3696C0E35CB4A00A77F284779E03FBED6B46D9EE00CA261D2B467064A3D149'
+    PatchedHash = '1AB5261A714BDD10BCE038319A4668E366B679691A746B569731ED994FAC80E3'
   }
 }
 $ProfileLabel = $SkyVersion

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0')]
+  [ValidateSet('0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -68,6 +68,12 @@ $Profiles = @{
     SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
     OriginalHash = 'DE3696C0E35CB4A00A77F284779E03FBED6B46D9EE00CA261D2B467064A3D149'
     PatchedHash = '1AB5261A714BDD10BCE038319A4668E366B679691A746B569731ED994FAC80E3'
+  }
+  # Same sky version string as DE3696C0, different binary: keyed on hash, not version.
+  '0.6.24-4DB7B670' = [ordered]@{
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalHash = '4DB7B6709F5B6DB2AE6DF60A1BDE026CF8A3582EEB616AF6B6529150E11B5CE1'
+    PatchedHash = '986AA8DC4F6B2DC0A9551617120AF82915EC42C9F745BDE5F474EEB44A6ACCBD'
   }
 }
 $ProfileLabel = $SkyVersion


### PR DESCRIPTION
Desktop builds shipping `@oai/sky` 0.6.23/0.6.24 changed three minified gate shapes and introduced four new Computer Use helper binaries. This adds support for all of them without touching any existing code path.

## Gate shapes

Each change is applied to **both** the PowerShell discovery predicate and the embedded Node patcher, so discovery and patching stay in agreement. A shape that only one side recognizes produces either a false "target not found" or a silent no-op patch.

**Custom model visibility.** A `hasConfiguredModelCatalog&&!model.hidden||` disjunct is now inserted ahead of the `useHiddenModels` ternary, and that ternary gained one more paren layer. Added as a fifth pattern rather than relaxing the existing four, so the older shapes keep matching exactly as before.

**Sidebar availability.** Two independent changes here:

- The `browser.in-app` capability entry is now prefixed with `accessPolicy`. Stripping only `configFeatures` is not enough: the capability atom short-circuits to `isCapable:!0` only when the whole requirement list comes out empty, so every requirement key has to go.
- The capability-read helper is renamed by the minifier on every release (`hs` -> `k_` in 0.6.24), so the fallback matches any identifier instead of a fixed one.

The existing numeric-literal path is left exactly as it was. The new structural anchors are tried only when it does not match, because that literal rotates between builds and does not appear at all in 0.6.24. Keeping both means older builds still take the original path.

**Ultra slider.** The conversation client moved behind a dynamic `import()` inside `queryFn`, and the returned object gained keys (`chatTheme`). Rather than widen the named-group reconstruction again, the whole success body is now captured verbatim and re-emitted inside the `try`. Any field the build returns is preserved, so a future added key does not silently get dropped from the patched object.

## Helper profiles

- **0.6.23 `8423CA8C`**, validated on Desktop `26.820.10647.0`.
- **0.6.24 `DE3696C0`**, validated on Desktop `26.825.3734.0`.
- **0.6.24 `4DB7B670`**, validated on Desktop `26.825.4187.0`.
- **0.6.24 `9BAB6E1B`**, validated on Desktop `26.825.5331.0`.

These four are the same code re-signed four times. `DE3696C0` is the 0.6.23 binary re-signed: every section body is byte-identical, and the only differences are the COFF timestamp, the optional-header checksum, and the Authenticode trailer after `.reloc`. `4DB7B670` is `DE3696C0` re-signed again, and is cleaner still: all nine section bodies are byte-identical and the whole file differs in only **two** bytes, the optional-header checksum at `0xD8..0xD9`.

`9BAB6E1B` is `4DB7B670` re-signed a third time. All three files are 1,510,704 bytes. The 400-byte section table is byte-identical, all nine sections that carry raw data have identical bodies (`.bss` has `vsize=704` and `raw=0`, so there is no body to compare), and the COFF timestamp is unchanged at `0x6A8F8FF4`. Of the 1964 differing whole-file bytes, spread over 47 runs, 2 fall in the optional-header checksum (`0x00173283` -> `0x0017A30C`) and the remaining 1962 in the certificate area, ending at `0x00170D2C`. Zero bytes differ outside those two areas.

All five guarded regions therefore carry over at the same offsets with the same bytes in each of the four, and only the whole-file hashes change. That relationship is recorded as a comment above each profile so the next person does not have to re-derive it.

`DE3696C0`, `4DB7B670` and `9BAB6E1B` all report the *same* `SkyVersion` string, `0.6.24-premerge-pr-1369830-395ab116910c`, and hash differently. That is the clearest argument in this repo for the existing design: profiles are keyed on the complete helper SHA-256 **and** the exact `SkyVersion` string, never a version prefix. Matching on a version prefix would have silently selected the wrong byte offsets here.

## Test harness

The harness `ValidateSet` accepted ten labels while the patcher already shipped fifteen profiles, so the two oldest (`0.4.20-F2B2F56F` and `0.5.2-2C4CAC16`) could not be exercised at all. All six missing labels are now present, along with the four new ones, so `ValidateSet` and `$Profiles` are in one-to-one correspondence with the patcher in both directions.

The unsupported-binary arm also stopped hardcoding an offset. It flipped a bit at `$unknownBytes[0x47E01]`, which is 294,401 and therefore inside some helper binaries but past the end of others, so the assertion silently tested nothing for the smaller ones. It now flips the final byte (`$unknownBytes[$unknownBytes.Length - 1]`), which is in range for every profile regardless of binary size.

## Verification

- All three touched scripts parse cleanly (`[Parser]::ParseFile`, 0 errors).
- Every pre-existing upstream code path is still present and unmodified: the numeric-literal in-app browser chain, the `NodeReplTrustedPaths` patcher, `CODEX_NODE_REPL_TRUSTED_PATHS_V1`, `Test-CodeSigningCertificate`, the `currentManagerCachedAsync` fast-mode shape, and the `X509Store` certificate-trust path. Nothing was deleted or refactored.
- The five guarded regions in the new profiles were verified by reverse-applying the patched bytes and confirming the result hashes back to `OriginalSha256`.
- The four new helper profiles reach `original-patchable` and produce the recorded `PatchedSha256`.
- **All sixteen profiles pass the full harness**: install, idempotent install, rollback, idempotent rollback, and the unsupported-binary refusal. 16 pass, 0 fail, 0 skipped for a missing binary. Running the whole set rather than only the new profile is what catches a `ValidateSet` edit that displaces an existing label.
- `4DB7B670` and `9BAB6E1B` additionally ran on Windows 10 19045 against their respective Desktop builds, and the runtime helper reports `State=patched` after installation.

## Notes

Diff is 250 added / 7 removed. The 7 removed lines are all rewritten in place rather than dropped: in the msix patcher, the `queryRe` regex, its destructuring line, its replacement-string line, one sidebar guard line and one visibility-pattern line; in the test harness, the old `ValidateSet` line and the hardcoded-offset line.
