### PR TITLE
Stop stubbing globalThis.nodeRepl in the runtime import check

### DIFF
--- a/scripts/install-computer-use-local.ps1
+++ b/scripts/install-computer-use-local.ps1
@@ -3423,16 +3423,16 @@ function Test-ComputerUseRuntimeImport {
     throw "independent Computer Use runtime entry is missing: $entryPath"
   }
 
+  # Do not define globalThis.nodeRepl here. sky >= 0.6.24 branches three ways on
+  # it: undefined falls back to the standalone create_client(load_options()),
+  # which is exactly what an independent runtime import should exercise; defined
+  # with an rpc function routes every call over that RPC channel; defined without
+  # one throws "sky requires node_repl; configure NODE_REPL_TRUSTED_SERVICES" as
+  # soon as a method is touched. The stub removed here was that third shape, so
+  # this verification could never pass on 0.6.24. It only mirrored process.env
+  # values back, so it carried no information the standalone loader cannot read
+  # itself.
   $script = @'
-globalThis.nodeRepl = {
-  config: {},
-  nativePipe: {},
-  env: {
-    NODE_REPL_NODE_MODULE_DIRS:
-      process.env.NODE_REPL_NODE_MODULE_DIRS ?? process.env.NODE_PATH ?? "",
-  },
-  notify: () => {},
-};
 const mod = await import(process.argv[2]);
 if (typeof mod.sky !== "object" || mod.sky === null) {
   throw new Error("sky export is missing");


### PR DESCRIPTION
`Test-ComputerUseRuntimeImport` defines a `globalThis.nodeRepl` stub before importing the independent Computer Use runtime entry point. On `@oai/sky` 0.6.24 that stub is the one shape which makes the verification fail, so the check cannot pass on current Desktop builds.

## Why the stub breaks the check

`dist/project/cua/sky_js/src/sky.js` reads `globalThis.nodeRepl` once at module scope and then branches three ways inside the lazy resolver behind the exported `sky` Proxy:

```js
const o = globalThis.nodeRepl;
...
if (void 0 === o) return d = t(r()), d;                     // create_client(load_options())
if ("function" != typeof o.rpc)
  throw new Error("sky requires node_repl; configure NODE_REPL_TRUSTED_SERVICES");
// otherwise: route every method over o.rpc("sky", ...)
```

The stub sets `config`, `nativePipe`, `env` and `notify`, but no `rpc`. That lands on the middle branch. The throw is lazy because it lives in the Proxy's `get` trap, so `await import(...)` and the two `typeof` export assertions all succeed; the failure only appears at `await mod.sky.list_windows()`, which is the last thing the check does.

## Measured, on Desktop 26.825.5331.0 / sky 0.6.24-premerge-pr-1369830-395ab116910c

Same entry point, same Node 24.18.0, only the `globalThis.nodeRepl` shape varies:

| `globalThis.nodeRepl` | result | exit |
| --- | --- | --- |
| undefined | `{"ok":true,"windows":true,"count":5}` | 0 |
| stub without `rpc` (what this repo installs) | `Error: sky requires node_repl; configure NODE_REPL_TRUSTED_SERVICES` | 1 |
| stub with an `rpc` function | resolves over RPC, never touches the standalone loader | 0 |
| stub without `rpc`, import + export assertions only, no method call | `{"ok":true,"exports":["sky"]}` | 0 |

The first row is the intended behaviour of an *independent* runtime import: `create_client(load_options())` with no REPL in the picture. The third row shows why leaving a stub in place is wrong even if it were given an `rpc` function, since the check would then exercise the RPC transport rather than the standalone loader it is named after.

## Fix

Remove the stub from that one script block. Nothing replaces it: `load_options()` reads what it needs from the process environment itself, and the removed stub only mirrored `process.env.NODE_REPL_NODE_MODULE_DIRS ?? process.env.NODE_PATH` back. A comment records the three-way branch so the stub does not get reintroduced.

## Scope

One script block, `-9 +9` lines, comment included.

The identically shaped stub in `Test-ComputerUseClientImport` is **left alone deliberately**. That check asserts on `mod.setupComputerUseRuntime` and never calls a `sky` method, so the lazy throw is never reached (fourth row above). It also sets `NODE_PATH` / `NODE_REPL_NODE_MODULE_DIRS` to exercise runtime-root package resolution, which is the shape it is actually testing.

## Verification

- `[Parser]::ParseFile` on the modified script: 0 errors.
- Only one `globalThis.nodeRepl` site remains, the one in `Test-ComputerUseClientImport`.
- The four rows above were each run directly against the installed runtime entry, not simulated.

One note on reproducing this: `Get-CuaSkyRuntimeRoot` resolved to a stale `runtimes\cua_node\<hash>` directory on my machine, and importing a non-existent entry yields `ERR_MODULE_NOT_FOUND` rather than the sky error, which looks like a different failure. Confirm the entry file exists before drawing conclusions about which branch was taken.
