### PR TITLE
Keep the in_app_browser anchor when stripping the browser.in-app requirements

### DIFF
--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -1385,15 +1385,21 @@ function patchSidebarAvailability(file) {
     /([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(([A-Za-z_$][\w$]*),([A-Za-z_$][\w$]*)\)\.isCapable,([A-Za-z_$][\w$]*)=([A-Za-z_$][\w$]*)\(`410262010`\)/,
     '$1=!0,$5=($6(`410262010`),!0)/*CODEX_BROWSER_IN_APP_GATES_V2*/'
   );
-  // 0.6.24+ drops the `410262010` statsig literal entirely and prefixes the
-  // capability entry with accessPolicy, so anchor on the capability table
-  // instead. Strip every requirement key rather than just configFeatures: the
-  // capability atom short-circuits to isCapable:!0 only when the whole
-  // requirement list comes out empty.
+  // 0.6.24+ prefixes the capability entry with accessPolicy, and on some builds
+  // the `410262010` statsig literal no longer sits next to the isCapable read,
+  // so anchor on the capability table instead. Strip every requirement key
+  // rather than just configFeatures: the capability atom short-circuits to
+  // isCapable:!0 only when the whole requirement list comes out empty.
   const modernCapabilityPattern = /("browser\.in-app":\{)(?:accessPolicy:`[\w-]+`,|configFeatures:\[\{key:`in_app_browser`,host:`default`\}\],)+/;
-  const modernCapabilityPatched = /"browser\.in-app":\{supportedClients:\[`electron`\]\}/.test(before);
+  // Leave an `in_app_browser` marker behind. In the shipped bundle that literal
+  // occurs exactly once -- inside the configFeatures entry being stripped -- and
+  // both the entry guard above and the target-file discovery in
+  // patch_codex_fast_mode_windows_msix.ps1 key on it, so a bare strip would make
+  // this patcher unable to find its own target on a second run.
+  const modernCapabilityMarker = '/*in_app_browser CODEX_BROWSER_IN_APP_GATES_V2*/';
+  const modernCapabilityPatched = before.includes('"browser.in-app":{' + modernCapabilityMarker);
   const beforeModernCapability = after;
-  after = after.replace(modernCapabilityPattern, '$1');
+  after = after.replace(modernCapabilityPattern, '$1' + modernCapabilityMarker);
   if (after === beforeModernCapability && !modernCapabilityPatched) {
     after = after.replace(
       // The capability-read helper is renamed by the minifier on every release,


### PR DESCRIPTION
## Problem

PR #40 added a capability-table strip to `patchSidebarAvailability`:

```js
const modernCapabilityPattern = /("browser\.in-app":\{)(?:accessPolicy:`[\w-]+`,|configFeatures:\[\{key:`in_app_browser`,host:`default`\}\],)+/;
after = after.replace(modernCapabilityPattern, '$1');
```

In the shipped bundle the literal `in_app_browser` occurs **exactly once**, inside the
`configFeatures` entry that gets stripped. Verified on Desktop 26.825.5331.0 by mapping
asar byte offsets back to member files: the sidebar target
`/webview/assets/app-initial-DWX_sBmZ.js` contains it once (@rel 6326580); the only other
two occurrences in the whole archive are `featureName:` reads in
`browser-use-settings-*.js` and `browser-use-settings-visibility-*.js`, which are not
patch targets.

Three places key on that literal, so a bare strip makes the patcher unable to find its
own target after one successful pass:

- `patchSidebarAvailability`'s entry guard — `if (!before.includes('in_app_browser'))`
- target discovery in `patch_codex_fast_mode_windows_msix.ps1`, both the
  `browser-sidebar-availability-*.js` loop and the `app-initial-*.js` fallback
  (`$text.Contains('in_app_browser')`)

Consequences on 26.825.5331.0:

- a second patcher pass exits 2 with `browser-sidebar-availability-target-not-found`
- the PowerShell side reaches `Fail 'could not find browser sidebar availability gate in
  extracted assets'`, because discovery returns nothing

Re-running over an already patched package layout is a supported flow: the source root
comes from `Get-AppxPackage -Name OpenAI.Codex`'s `InstallLocation` (which is the patched
package after a successful run), and an existing work root is reused verbatim unless
`-ForceRebuild` is passed (`using existing work package layout`). It also turned
`test-browser-sidebar-gate-patterns.ps1`'s idempotency assertion red — that test went
from PASS on `main` to FAIL once #40 landed.

## Fix

Leave a `/*in_app_browser CODEX_BROWSER_IN_APP_GATES_V2*/` comment where the requirement
keys were, and key the already-patched check on that marker instead of on the bare
stripped shape. The runtime object is unchanged — the requirement list still comes out
empty, so the capability atom still short-circuits to `isCapable:!0`:

```
"browser.in-app":{/*in_app_browser CODEX_BROWSER_IN_APP_GATES_V2*/supportedClients:[`electron`]}
```

The comment marker also satisfies the existing `CODEX_BROWSER_IN_APP_GATES_V2`
alternative in the `app-initial-*.js` discovery branch, so discovery keeps working on
builds where the `410262010` replacement does not fire.

Also corrected the comment claim that 0.6.24 "drops the `410262010` statsig literal
entirely". On 26.825.5331.0 it is still present (once, at asar offset 27903220) and
`main`'s pre-existing pattern still matches it; the accurate statement is that on some
builds it no longer sits next to the `isCapable` read.

## Verification

Read-only / offline only — no MSIX repack, no install, no Desktop launch.

- Real asset, two consecutive passes over the extracted
  `/webview/assets/app-initial-DWX_sBmZ.js` (13,171,449 bytes): `patched` then
  `already-patched`, `in_app_browser` count stays 1, `node --check` clean. Before this
  fix the second pass exited 2 and the count dropped to 0.
- `test-browser-sidebar-gate-patterns.ps1`: child exit 0, regression passed.
- Full script suite: `PASS=15 NOT-PASS=3 parseFailures=0` over 32 scripts, verdict for
  verdict identical to the pre-#40 `main` baseline. The 3 not-pass are pre-existing on
  `main` and unrelated (`test-bundled-plugin-scope`,
  `test-computer-use-descriptor-only-layout`,
  `test-computer-use-node-repl-context-patch`).
