### PR TITLE
feat: support three Windows 10 helper profiles from Desktop 26.825.6671.0 and 26.831

### DIFF
--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -655,6 +655,182 @@ $PatchProfiles = @(
         PatchedHex = '20fb114001000000'
       }
     )
+  },
+  # Desktop 26.825.6671.0 ships a fifth binary reporting the same 0.6.24 sky
+  # version string. It is the 9BAB6E1B helper re-signed: the 400-byte section
+  # table is byte-identical, all nine sections that carry raw data have identical
+  # bodies (.bss has none), and the COFF timestamp is unchanged (0x6A8F8FF4). The
+  # 4225 differing whole-file bytes are fully accounted for by the optional-header
+  # checksum (2 bytes at 0xD8..0xD9, 0x0017A30C -> 0x0017D62D) plus the
+  # Authenticode certificate table (4223 bytes, last difference at 0x00170D2C);
+  # zero bytes differ outside those two areas. All five regions verified present
+  # at the same offsets with the same original bytes, so they carry over
+  # unchanged and only the whole-file hashes move.
+  [ordered]@{
+    Name = '@oai/sky 0.6.24 helper 3B60A7E0 / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.825.6671.0'
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalSha256 = '3B60A7E0746C9FCEEBC3E0735C33BF97734B4B2AA04E0ED030201251E48D1BB6'
+    PatchedSha256 = '8B09F9EFD541E059D6611B0D00C6984A2ACF19971B45F292DF3EE13F746009D7'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D71A
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x0004133E
+        OriginalHex = '0f8543310000'
+        PatchedHex = '0f8525310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x0004134F
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x0011EF20
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff1507d404004885c074104889c1ff15c1d3040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff1501d30400488b4c2428e85823f2ffff15f9d20400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x00124C10
+        OriginalHex = '091f044001000000'
+        PatchedHex = '20fb114001000000'
+      }
+    )
+  }
+  # Desktop 26.831.1445.0 ships @oai/sky 0.6.26. Unlike the three 0.6.24
+  # binaries above this is a genuine recompile, not a re-signed clone: the file
+  # grew 38912 bytes, all five region bodies moved, and the section table
+  # differs. Every value below was re-derived against this binary rather than
+  # carried over:
+  #   optional-border-interface  0x0003D71A -> 0x0003D7AC (+0x92). Same eight
+  #     original bytes. The QueryInterface(IGraphicsCaptureSession3) failure arm
+  #     still sits 0x20 bytes short of the success continuation, so the rel32
+  #     stays 0x6F: jmp 0x14003E420 (mov rax,[r12]) skipping the
+  #     "SetIsBorderRequired failed" report at 0x14003E400.
+  #   frame-arrived-busy-return  0x0004133E -> 0x000413D0 (+0x92), but its
+  #     target did not shift by the same amount, so the rel32 was recomputed
+  #     from the two landing sites instead of adjusted: the contended
+  #     "mov rcx,rsi / call 0x1400C8D60 / jmp back" block is at 0x140045131 and
+  #     the S_OK epilogue (xor eax,eax / restore xmm6 / pops / ret) at
+  #     0x140045113, so 0x315B -> 0x313D.
+  #   frame-arrived-once-flag    busy-return + 0x11, unchanged 740d -> eb0d.
+  #   mta-worker-wrapper         this build has exactly one free run of 169+
+  #     bytes in its only executable section: the .text tail pad at raw
+  #     0x001266F0 / rva 0x001272F0, 272 bytes. The blob is placed 0x100-aligned
+  #     at rva 0x00127300. That is past .text VirtualSize (0x001262F8) but
+  #     inside SizeOfRawData (0x00126400); reading a live process at that RVA
+  #     returns the blob, so the loader maps the whole raw section and no
+  #     section-header edit is needed. The four ff15 thunks were re-resolved by
+  #     name from the import directory (CreateThread 0x177018, CloseHandle
+  #     0x176FD8, RoInitialize 0x176F30, RoUninitialize 0x176F38) and the e8
+  #     retargeted to the original handler at 0x140041F9B; the lea r8,[rip+0x49]
+  #     is blob-relative and unchanged.
+  #   frame-arrived-vtable       0x00124C10 -> 0x0012C4B8, unique 8-byte slot
+  #     holding 0x140041F9B, replaced with the wrapper VA 0x140127300.
+  # Verified on the real binary before install: the unpatched helper answers
+  # get_window_state with "SetIsBorderRequired failed ... (0x80004002)" while a
+  # scratch copy carrying these five regions returns a decodable JPEG, and ten
+  # back-to-back captures ran 28-43 ms each with no deadlock.
+  [ordered]@{
+    Name = '@oai/sky 0.6.26 helper 7D9EB53D / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.831.1445.0'
+    SkyVersion = '0.6.26'
+    OriginalSha256 = '7D9EB53D9C7C6AFFD05443227C9D93720B9FBD7EADF9B98D7A83D28703ACA95D'
+    PatchedSha256 = '79EF9E7971E3B7BBF0FFFA6D096107196F08F008BF70D73E9141D96991748228'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D7AC
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x000413D0
+        OriginalHex = '0f855b310000'
+        PatchedHex = '0f853d310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x000413E1
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x00126700
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15d7fc04004885c074104889c1ff1589fc040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15a9fb0400488b4c2428e80aacf1ffff15a1fb0400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0012C4B8
+        OriginalHex = '9b1f044001000000'
+        PatchedHex = '0073124001000000'
+      }
+    )
+  }
+  # Desktop 26.831.2377.0 ships the same sky code re-signed under a prerelease
+  # version string: 0.6.26-premerge-pr-1403760-d558d5ad5c81. Because profile
+  # selection requires SkyVersion equality, the 0.6.26 entry above cannot serve
+  # it even though the machine code is the same, so this entry exists purely to
+  # carry the new hash pair and the new version string.
+  #
+  # Same-code proof, run before adding this entry rather than assumed from the
+  # equal file size (both are 1549616 bytes): all ten sections compare
+  # byte-identical over their whole SizeOfRawData spans (.text .data .rdata
+  # .pdata .xdata .bss .idata .CRT .tls .reloc, body_diff=0 each) and the section
+  # table itself is identical field for field. The 2585 differing bytes fall in
+  # exactly two places -- the PE checksum at raw 0x88 / 0xD8, and the Authenticode
+  # and debug-stamp area past .reloc's raw end (0x176800 onward). All five region
+  # bodies still read their expected OriginalHex at the same offsets, so every
+  # offset and both hex strings are reused verbatim from the entry above.
+  [ordered]@{
+    Name = '@oai/sky 0.6.26-premerge-pr-1403760 helper 52928CCC / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.831.2377.0'
+    SkyVersion = '0.6.26-premerge-pr-1403760-d558d5ad5c81'
+    OriginalSha256 = '52928CCCDECCFC245661733E5903335642AEC1726A6DA4B3A8A8E683805A2769'
+    PatchedSha256 = '0680CEBCA4C7EB49783578BAEA42DDD0B620379EC2AAA3A4DEBC8FA21BFB832A'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D7AC
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x000413D0
+        OriginalHex = '0f855b310000'
+        PatchedHex = '0f853d310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x000413E1
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x00126700
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15d7fc04004885c074104889c1ff1589fc040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15a9fb0400488b4c2428e80aacf1ffff15a1fb0400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0012C4B8
+        OriginalHex = '9b1f044001000000'
+        PatchedHex = '0073124001000000'
+      }
+    )
   }
 )
 

--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -704,7 +704,7 @@ $PatchProfiles = @(
         PatchedHex = '20fb114001000000'
       }
     )
-  }
+  },
   # Desktop 26.831.1445.0 ships @oai/sky 0.6.26. Unlike the three 0.6.24
   # binaries above this is a genuine recompile, not a re-signed clone: the file
   # grew 38912 bytes, all five region bodies moved, and the section table
@@ -777,7 +777,7 @@ $PatchProfiles = @(
         PatchedHex = '0073124001000000'
       }
     )
-  }
+  },
   # Desktop 26.831.2377.0 ships the same sky code re-signed under a prerelease
   # version string: 0.6.26-premerge-pr-1403760-d558d5ad5c81. Because profile
   # selection requires SkyVersion equality, the 0.6.26 entry above cannot serve

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670', '0.6.24-9BAB6E1B')]
+  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670', '0.6.24-9BAB6E1B', '0.6.24-3B60A7E0', '0.6.26-7D9EB53D', '0.6.26-52928CCC')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -90,6 +90,25 @@ $Profiles = @{
     SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
     OriginalHash = '9BAB6E1B59D31D97530F2F6681DAEF76E39C7AD0836147C6E0B55A9B47A33EBF'
     PatchedHash = 'B86B1FCB9EBD7184526AF49D40333FDA02F774FA62E0E9A3528BA5F87EB68AB7'
+  }
+  # Fourth binary on the same 0.6.24 sky version string, shipped by Desktop 26.825.6671.0.
+  '0.6.24-3B60A7E0' = [ordered]@{
+    SkyVersion = '0.6.24-premerge-pr-1369830-395ab116910c'
+    OriginalHash = '3B60A7E0746C9FCEEBC3E0735C33BF97734B4B2AA04E0ED030201251E48D1BB6'
+    PatchedHash = '8B09F9EFD541E059D6611B0D00C6984A2ACF19971B45F292DF3EE13F746009D7'
+  }
+  # First 0.6.26 helper, shipped by Desktop 26.831.1445.0 with a bare version string.
+  '0.6.26-7D9EB53D' = [ordered]@{
+    SkyVersion = '0.6.26'
+    OriginalHash = '7D9EB53D9C7C6AFFD05443227C9D93720B9FBD7EADF9B98D7A83D28703ACA95D'
+    PatchedHash = '79EF9E7971E3B7BBF0FFFA6D096107196F08F008BF70D73E9141D96991748228'
+  }
+  # Same code as 7D9EB53D re-signed under a prerelease version string, shipped by
+  # Desktop 26.831.2377.0. Selection needs SkyVersion equality, so it needs its own entry.
+  '0.6.26-52928CCC' = [ordered]@{
+    SkyVersion = '0.6.26-premerge-pr-1403760-d558d5ad5c81'
+    OriginalHash = '52928CCCDECCFC245661733E5903335642AEC1726A6DA4B3A8A8E683805A2769'
+    PatchedHash = '0680CEBCA4C7EB49783578BAEA42DDD0B620379EC2AAA3A4DEBC8FA21BFB832A'
   }
 }
 $ProfileLabel = $SkyVersion


### PR DESCRIPTION
Three helper profiles for Desktop builds that shipped after c2c6b78, plus their regression labels.

## Profiles

| label | SkyVersion | original -> patched | shipped by |
| --- | --- | --- | --- |
| `0.6.24-3B60A7E0` | `0.6.24-premerge-pr-1369830-395ab116910c` | `3B60A7E0...` -> `8B09F9EF...` | Desktop 26.825.6671.0 |
| `0.6.26-7D9EB53D` | `0.6.26` | `7D9EB53D...` -> `79EF9E79...` | Desktop 26.831.1445.0 |
| `0.6.26-52928CCC` | `0.6.26-premerge-pr-1403760-d558d5ad5c81` | `52928CCC...` -> `0680CEBC...` | Desktop 26.831.2377.0 |

Full hashes are in the profile table.

- `3B60A7E0` is the **fourth** distinct binary carrying the same `0.6.24` sky version
  string. More evidence that selection has to stay whole-file-hash based.
- `52928CCC` is the same code as `7D9EB53D`, re-signed under a prerelease version string.
  Every section compares byte-identical over its full `SizeOfRawData` and the two section
  tables match; the only differing bytes are the PE checksum (raw `0x88`/`0xD8`) and the
  Authenticode/debug area past `.reloc`'s raw end. Because profile selection requires
  `SkyVersion` **equality** rather than a prefix match, it still needs its own entry — the
  region offsets and hex are reused verbatim from `7D9EB53D` on the strength of that proof.
- Each profile carries all five guarded regions, including the 169-byte
  `mta-worker-wrapper` stub at `0x00126700` and `frame-arrived-vtable` at `0x0012C4B8`.
  Patching only the first three regions deadlocks the helper on its first frame, so the
  five are one unit.

## Validation

- `test-computer-use-helper-win10-patch.ps1` reports `ALL_TESTS_PASSED` for
  `0.6.24-3B60A7E0`, `0.6.26-7D9EB53D` and `0.6.26-52928CCC`; the pre-existing
  `0.6.24-9BAB6E1B` label still passes. No fixtures left behind under TEMP.
- Runtime soak against the currently installed helper (`52928CCC` -> `0680CEBC`, Desktop
  26.831.2377.0): 25/25 captures OK, 9 distinct frames, steady state 31-51 ms. The soak
  target has to be a **continuously animating** window — the same soak against a static
  one returns `1/12 distinct`, because `FrameArrived` never fires and the three frame-pump
  regions go completely untested. Also worth knowing: a minimized window has no capture
  surface, so the sequence is `activate_window` -> sleep -> re-`get_window` for a fresh
  handle -> capture.
- The other two profiles were validated the same way while their build was the installed
  one.
- Every profile block already on `main` is byte-identical in this branch. It is cut from
  c2c6b78 and adds only the three entries plus the harness `ValidateSet` / `$Profiles`
  labels.

## Deliberately out of scope

`patch_codex_fast_mode_windows_msix.ps1` is untouched here. c2c6b78 already adapted the
msix patcher to the 26.831 build shapes, and my local tree happens to solve the same
problems by different mechanisms (a `queryHeadRe` hard-fail, `patchModernFeatureHook`,
`currentAuthOnlyFastModeRe`) while *lacking* the `/goal` scorer branch and the `_V3`
config path that `main` now has. So it is a bidirectional conflict, not an addition — the
same kind of overlap that was declined in #29. If any of it is wanted, it belongs in a
separate PR reviewed hunk by hunk.

One note from working with the current patcher: `patchModernFeatureHook` opens the two
browser gates by rewriting ``=GNr(x),`` -> `={enabled:!0,isLoading:!1},` and
``=fn(`digits`),`` -> `=!0,` **without writing any `CODEX_*` marker**, so marker presence
is the wrong acceptance criterion for those two gates. On 26.831.2377.0 the semantic check
is `browser_use` / `browser_use_external` hooks open, `harborEnabled:` member count 0
(the gate really is gone, so the already-patched branch is correct to do nothing) and
slider token count 66 (the feature itself was not removed).
