### PR TITLE
fix: tolerate the browser-use marker in the computer-use availability witness

### DIFF
--- a/scripts/patch_codex_fast_mode_windows_msix.ps1
+++ b/scripts/patch_codex_fast_mode_windows_msix.ps1
@@ -1218,7 +1218,13 @@ function patchComputerUseAvailability(file) {
     '$1$2={enabled:!0,isLoading:!1},'
   );
 
-  if (after === before && !/featureName:`computer_use`[^;]+;let [A-Za-z_$][\w$]*=\{enabled:!0,isLoading:!1\},/.test(before)) {
+  // The browser-use patch runs first and its inAppConfigV3 replacement already rewrites this
+  // same declaration, appending a /*CODEX_BROWSER_IN_APP_CONFIG_V3*/ marker between the object
+  // literal and the following comma. So on a re-patch of an already-patched package the second
+  // replace above has nothing left to do and the witness must tolerate that marker, otherwise
+  // a correctly patched build is reported as target-not-found.
+  const availabilityPatchedRe = /featureName:`computer_use`[^;]+;let [A-Za-z_$][\w$]*=\{enabled:!0,isLoading:!1\}(?:\/\*[^*]*\*\/)?,/;
+  if (after === before && !availabilityPatchedRe.test(before)) {
     process.stderr.write('computer-use-availability-patch-target-not-found\n');
     process.exit(2);
   }


### PR DESCRIPTION
## Symptom

Repacking a source package whose `app.asar` has already been patched aborts at the
computer-use gate step with

```
computer-use-availability-patch-target-not-found
```

and `EXITCODE=1`. The package is fine; the idempotency witness is what fails. Because the
patcher exits 2, a re-run over an already-good tree cannot complete at all.

## Root cause

`PatchBrowserUseGates.cjs` and `PatchComputerUseGates.cjs` rewrite **the same declaration in
the same asset chunk**, and browser-use runs first:

```powershell
$browserUse   = Invoke-NodePatcher $nodePath $patchers.BrowserUse   ...   # earlier
$computerUse  = Invoke-NodePatcher $nodePath $patchers.ComputerUse  ...   # later
```

They can land on one file by construction: the browser-use feature-hook target is only accepted
when it contains ``featureName:`browser_use_external` ``, ``featureName:`browser_use` `` **and**
``featureName:`computer_use` ``, while the computer-use availability target is chosen from the
``featureName:`computer_use` `` ripgrep hit list. On the shipped bundle both resolve to the same
chunk.

browser-use's `inAppConfigV3` replacement emits

```js
'let $1={enabled:!0,isLoading:!1}/*CODEX_BROWSER_IN_APP_CONFIG_V3*/$2'
```

so the marker ends up **between the object literal and the following comma**. On the second run
`patchComputerUseAvailability`'s own replace then correctly has nothing left to do
(`after === before`), which is normal idempotency - but its witness required

```js
/featureName:`computer_use`[^;]+;let [A-Za-z_$][\w$]*=\{enabled:!0,isLoading:!1\},/
```

`}` immediately followed by `,`. Separated by the marker, it matches zero times, so a correctly
patched build is reported as a missing target.

## What changes

The witness becomes a named regex with an optional comment group between `}` and `,`:

```js
const availabilityPatchedRe = /featureName:`computer_use`[^;]+;let [A-Za-z_$][\w$]*=\{enabled:!0,isLoading:!1\}(?:\/\*[^*]*\*\/)?,/;
if (after === before && !availabilityPatchedRe.test(before)) {
```

The failure criterion is unchanged in spirit and stays two-part: **the replace did nothing AND
the witness does not match**. A no-op replace on its own is not evidence of a missing target -
that is exactly the case this bug misread. No behaviour change on a clean source package: the
first-run path still takes the replace branch.

The sibling `browser-sidebar-availability` witness is not affected; it keys on the capability
table and already carries its own `modernCapabilityPatched` guard.

## Verification

- `scripts/test-fast-mode-gate-patterns.ps1` passes.
- Verified end to end on **Codex Desktop 26.901.2854.0** / codex-cli 0.153.0: a repack of an
  already-patched source package now completes instead of exiting 2 at the computer-use gate,
  and a clean package still patches identically.
