### PR TITLE
feat: add @oai/sky 0.6.26 helper profiles 71BAEAFD and 243F203E

### DIFF
--- a/scripts/patch-computer-use-helper-win10.ps1
+++ b/scripts/patch-computer-use-helper-win10.ps1
@@ -831,6 +831,84 @@ $PatchProfiles = @(
         PatchedHex = '0073124001000000'
       }
     )
+  },
+  [ordered]@{
+    Name = '@oai/sky 0.6.26 helper 71BAEAFD / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.901.1978.0'
+    SkyVersion = '0.6.26'
+    OriginalSha256 = '71BAEAFD97639C170BA2954DFBF6677B6C30171E570C8105290265705C86E102'
+    PatchedSha256 = '06EBD6D68DF7CF3D3DAB02BD8D886D49D9D181949986DDF2F567A947F75C3A13'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D7AC
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x000413D0
+        OriginalHex = '0f855b310000'
+        PatchedHex = '0f853d310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x000413E1
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x00126700
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15d7fc04004885c074104889c1ff1589fc040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15a9fb0400488b4c2428e80aacf1ffff15a1fb0400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0012C4B8
+        OriginalHex = '9b1f044001000000'
+        PatchedHex = '0073124001000000'
+      }
+    )
+  },
+  [ordered]@{
+    Name = '@oai/sky 0.6.26 helper 243F203E / Windows 10 screenshot backend'
+    ValidatedDesktopVersion = '26.901.2854.0'
+    SkyVersion = '0.6.26'
+    OriginalSha256 = '243F203ED85CDA954A12872A0214FF8D43FD09F265AAE172D96AF1A1C1BBFF6B'
+    PatchedSha256 = 'C62CBDCC42EF6238CD96FD123246D7D820DA2EA341FD63B9F1890B124A530B40'
+    Regions = @(
+      [ordered]@{
+        Name = 'optional-border-interface'
+        Offset = 0x0003D7AC
+        OriginalHex = '4889c64189d6eb4c'
+        PatchedHex = 'e96f000000909090'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-busy-return'
+        Offset = 0x000413D0
+        OriginalHex = '0f855b310000'
+        PatchedHex = '0f853d310000'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-once-flag'
+        Offset = 0x000413E1
+        OriginalHex = '740d'
+        PatchedHex = 'eb0d'
+      },
+      [ordered]@{
+        Name = 'mta-worker-wrapper'
+        Offset = 0x00126700
+        OriginalHex = (('00' * 169) -join '')
+        PatchedHex = '4883ec3848894c24304c8b510831c0b201f0410fb052117536488b01ff500831c931d24c8d05490000004c8b4c2430488364242000488364242800ff15d7fc04004885c074104889c1ff1589fc040031c04883c438c3488b4c2430488b4108c6401100488b01ff5010b8054000804883c438c34883ec3848894c2428b901000000ff15a9fb0400488b4c2428e80aacf1ffff15a1fb0400488b4c2428488b01ff501031c04883c438c3'
+      },
+      [ordered]@{
+        Name = 'frame-arrived-vtable'
+        Offset = 0x0012C4B8
+        OriginalHex = '9b1f044001000000'
+        PatchedHex = '0073124001000000'
+      }
+    )
   }
 )
 

--- a/scripts/test-computer-use-helper-win10-patch.ps1
+++ b/scripts/test-computer-use-helper-win10-patch.ps1
@@ -3,7 +3,7 @@ param(
   [string]$HelperPath,
   # Profile labels, not raw @oai/sky versions: one sky version can ship more than one
   # helper binary across Desktop builds, so each label pins its own hash pair.
-  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670', '0.6.24-9BAB6E1B', '0.6.24-3B60A7E0', '0.6.26-7D9EB53D', '0.6.26-52928CCC')]
+  [ValidateSet('0.4.20-F2B2F56F', '0.5.2-2C4CAC16', '0.6.6', '0.6.11', '0.6.11-7A95D14E', '0.6.16', '0.6.16-BEB498C2', '0.6.17-29D5E113', '0.6.17-DB8F4486', '0.6.17-4250FF66', '0.6.17-4319D3A2', '0.6.17-D967386B', '0.6.23-8423CA8C', '0.6.24-DE3696C0', '0.6.24-4DB7B670', '0.6.24-9BAB6E1B', '0.6.24-3B60A7E0', '0.6.26-7D9EB53D', '0.6.26-52928CCC', '0.6.26-71BAEAFD', '0.6.26-243F203E')]
   [string]$SkyVersion = '0.6.16'
 )
 
@@ -109,6 +109,20 @@ $Profiles = @{
     SkyVersion = '0.6.26-premerge-pr-1403760-d558d5ad5c81'
     OriginalHash = '52928CCCDECCFC245661733E5903335642AEC1726A6DA4B3A8A8E683805A2769'
     PatchedHash = '0680CEBCA4C7EB49783578BAEA42DDD0B620379EC2AAA3A4DEBC8FA21BFB832A'
+  }
+  # Same code as 7D9EB53D and 52928CCC re-signed again, shipped by Desktop 26.901.1978.0.
+  '0.6.26-71BAEAFD' = [ordered]@{
+    SkyVersion = '0.6.26'
+    OriginalHash = '71BAEAFD97639C170BA2954DFBF6677B6C30171E570C8105290265705C86E102'
+    PatchedHash = '06EBD6D68DF7CF3D3DAB02BD8D886D49D9D181949986DDF2F567A947F75C3A13'
+  }
+  # Fourth re-sign of the same code, shipped by Desktop 26.901.2854.0. Only the PE
+  # CheckSum field and the certificate table differ from 71BAEAFD; all 10 section
+  # bodies are byte-identical, so the five patch offsets carry over unchanged.
+  '0.6.26-243F203E' = [ordered]@{
+    SkyVersion = '0.6.26'
+    OriginalHash = '243F203ED85CDA954A12872A0214FF8D43FD09F265AAE172D96AF1A1C1BBFF6B'
+    PatchedHash = 'C62CBDCC42EF6238CD96FD123246D7D820DA2EA341FD63B9F1890B124A530B40'
   }
 }
 $ProfileLabel = $SkyVersion


### PR DESCRIPTION
## Symptom

Two `@oai/sky 0.6.26` helper binaries shipped after `52928CCC` and neither had a profile, so

```
patch-computer-use-helper-win10.ps1
test-computer-use-helper-win10-patch.ps1 -SkyVersion ...
```

could not run against them: the profile lookup finds nothing, `-SkyVersion` rejects the label,
and the hash-pin branch of the regression is unreachable. The Windows 10 screenshot backend on
those Desktop builds therefore stays unpatched.

## Why a new profile is needed for an unchanged sky version

Profiles are selected on **whole-file SHA-256 + `SkyVersion` equality**, never on a version prefix
or file size, because one sky version can ship several distinct binaries: a re-sign changes the
hash while `SkyVersion` stays `0.6.26`. Both binaries below are that case.

```
Desktop 26.901.1978.0   71BAEAFD97639C170BA2954DFBF6677B6C30171E570C8105290265705C86E102
                     -> 06EBD6D68DF7CF3D3DAB02BD8D886D49D9D181949986DDF2F567A947F75C3A13

Desktop 26.901.2854.0   243F203ED85CDA954A12872A0214FF8D43FD09F265AAE172D96AF1A1C1BBFF6B
                     -> C62CBDCC42EF6238CD96FD123246D7D820DA2EA341FD63B9F1890B124A530B40
```

Helper size is 1549616 bytes in both cases.

## Same-code re-sign, proven before reuse

Both are same-code re-signs of `52928CCC`, so the five region offsets and hex are reused verbatim
rather than re-derived. That reuse is only valid because it was proven first, not inferred from
equal file size: **per-section `body_diff` is 0 and the section tables are equal**. Lineage is now

```
7D9EB53D -> 52928CCC -> 71BAEAFD -> 243F203E
```

Regions (identical across the lineage):

```
optional-border-interface   0x0003D7AC   4889c64189d6eb4c -> e96f000000909090
frame-arrived-busy-return   0x000413D0   0f855b310000     -> 0f853d310000
frame-arrived-once-flag     0x000413E1   740d             -> eb0d
mta-worker-wrapper          0x00126700   00 x169          -> 169-byte stub
frame-arrived-vtable        0x0012C4B8   9b1f044001000000 -> 0073124001000000
```

## Harness labels in the same change

A profile added without its harness label leaves `-SkyVersion` unable to drive the regression, so
both files move together. Labels are the **keys** of the `Profiles` hashtable, not values computed
from `SkyVersion + OriginalSha256[0..7]` - historical labels are bare versions such as `0.6.6` and
`0.6.16`, so deriving them produces false mismatches. The alignment check is set equality:

```
patch-computer-use-helper-win10.ps1        OriginalSha256=21  PatchedSha256=21
                                           Name='@oai/sky ...'=21  SkyVersion=21
test-computer-use-helper-win10-patch.ps1   ValidateSet=21  Profiles keys=21
ValidateSet set == Profiles key set        True
```

Counted with four mutually independent regexes rather than one.

## Verification

Run on **Codex Desktop 26.901.2854.0**:

- `test-computer-use-helper-win10-patch.ps1 -SkyVersion 0.6.26-243F203E` -> `ALL_TESTS_PASSED`,
  taking the hash-pin branch (patch -> verify -> idempotent re-run -> rollback -> idempotent
  rollback).
- Patched helper hash re-measured from disk after install and equal to `PatchedSha256`.
- Soak test 25/25 rounds against a continuously animating window, 18 distinct frames, single-frame
  latency min 35 / median 36 / max 147 ms.
