### PR TITLE
Fix -VerifyAllBundledPluginsAvailable on builds shipping an INTERNAL_ONLY plugin

### DIFF
--- a/scripts/install-computer-use-local.ps1
+++ b/scripts/install-computer-use-local.ps1
@@ -1621,6 +1621,38 @@ function Get-BundledMarketplacePluginNames {
   return $pluginNames
 }
 
+function Get-BundledMarketplacePluginPublicationPolicy {
+  param(
+    [string]$MarketplaceRoot,
+    [string]$PluginName
+  )
+
+  # Descriptors marked INTERNAL_ONLY are deliberately withheld from the
+  # marketplace mirror Desktop generates, so the CLI can never offer them.
+  $descriptorPath = Join-Path $MarketplaceRoot "plugins\$PluginName\.codex-plugin\plugin.json"
+  if (-not (Test-Path -LiteralPath $descriptorPath -PathType Leaf)) {
+    return ''
+  }
+
+  try {
+    $descriptor = Get-Content -Raw -Encoding UTF8 -LiteralPath $descriptorPath | ConvertFrom-Json -ErrorAction Stop
+  } catch {
+    return ''
+  }
+
+  return [string]$descriptor.publicationPolicy
+}
+
+function Test-BundledMarketplacePluginPublishable {
+  param(
+    [string]$MarketplaceRoot,
+    [string]$PluginName
+  )
+
+  $policy = Get-BundledMarketplacePluginPublicationPolicy $MarketplaceRoot $PluginName
+  return -not ($policy -and $policy.Trim() -ieq 'INTERNAL_ONLY')
+}
+
 function Get-BundledMarketplacePluginVersions {
   param(
     [string]$MarketplaceRoot,
@@ -1746,9 +1778,22 @@ function Test-AllBundledMarketplacePluginsAvailableWithCodexCli {
     }
   }
 
+  # The descriptor-set and version checks above compare two raw copies of the
+  # package, so they legitimately cover every descriptor. CLI discovery cannot:
+  # Desktop drops INTERNAL_ONLY descriptors when it builds the marketplace
+  # mirror the CLI actually reads, so requiring them here fails every build that
+  # ships one (26.901.6511.0 ships user-writing 0.1.2 that way).
+  $publishableNames = @($pluginNames | Where-Object {
+    Test-BundledMarketplacePluginPublishable $InstalledMarketplaceRoot $_
+  })
+  $withheldNames = @($pluginNames | Where-Object { $publishableNames -notcontains $_ })
+  if ($withheldNames.Count -gt 0) {
+    Write-Log "bundled plugins withheld from the marketplace mirror (INTERNAL_ONLY): $($withheldNames -join ',')"
+  }
+
   $pluginList = Get-BundledMarketplacePluginListWithCodexCli -IncludeAvailable
   $entries = @($pluginList.installed) + @($pluginList.available)
-  foreach ($pluginName in $pluginNames) {
+  foreach ($pluginName in $publishableNames) {
     $selector = "$pluginName@openai-bundled"
     $availablePlugins = @($entries | Where-Object {
       [string]$_.pluginId -eq $selector
@@ -1778,7 +1823,7 @@ function Test-AllBundledMarketplacePluginsAvailableWithCodexCli {
       throw "bundled plugin has no installable local source: $selector"
     }
   }
-  Write-Log "all bundled marketplace plugins are available without changing install state: $($pluginNames -join ',')"
+  Write-Log "all publishable bundled marketplace plugins are available without changing install state: $($publishableNames -join ',')"
 }
 
 function Sync-OpenAiBundledPluginCache {

--- a/scripts/test-bundled-plugin-scope.ps1
+++ b/scripts/test-bundled-plugin-scope.ps1
@@ -67,7 +67,7 @@ if ($availabilityExitCode -ne 0) {
   throw "Bundled plugin availability verification failed: $($availabilityOutput -join [Environment]::NewLine)"
 }
 $availabilityText = ($availabilityOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
-if ($availabilityText -notmatch '(?m)^\[codex-computer-use-local\] all bundled marketplace plugins are available without changing install state:') {
+if ($availabilityText -notmatch '(?m)^\[codex-computer-use-local\] all publishable bundled marketplace plugins are available without changing install state:') {
   throw "Bundled plugin availability verification did not report its read-only success marker: $availabilityText"
 }
 

--- a/scripts/test-bundled-plugin-version-drift.ps1
+++ b/scripts/test-bundled-plugin-version-drift.ps1
@@ -34,7 +34,8 @@ $stableRoot = Join-Path $fixtureRoot 'stable'
 function Set-FixtureMarketplace {
   param(
     [string]$Root,
-    [string]$Version
+    [string]$Version,
+    [string]$PublicationPolicy
   )
 
   $descriptorRoot = Join-Path $Root 'plugins\fixture\.codex-plugin'
@@ -44,6 +45,9 @@ function Set-FixtureMarketplace {
   $descriptor = [ordered]@{
     name = 'fixture'
     version = $Version
+  }
+  if (-not [string]::IsNullOrWhiteSpace($PublicationPolicy)) {
+    $descriptor['publicationPolicy'] = $PublicationPolicy
   }
   $manifest = [ordered]@{
     name = 'openai-bundled'
@@ -120,8 +124,29 @@ Assert-ThrowsLike {
 Set-FixtureCliVersion '2.0.0'
 $successOutput = @(Test-AllBundledMarketplacePluginsAvailableWithCodexCli $stableRoot $installedRoot 6>&1)
 $successText = ($successOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
-if ($successText -notmatch 'all bundled marketplace plugins are available without changing install state: fixture') {
+if ($successText -notmatch 'all publishable bundled marketplace plugins are available without changing install state: fixture') {
   throw "Matching descriptor versions did not report success: $successText"
 }
+
+# An INTERNAL_ONLY descriptor never reaches the marketplace mirror the CLI reads,
+# so requiring CLI discovery for it fails every build that ships one. The
+# descriptor-set and version comparisons still cover it: both sides are raw
+# copies of the package.
+Set-FixtureMarketplace $installedRoot '2.0.0' 'INTERNAL_ONLY'
+Set-FixtureMarketplace $stableRoot '2.0.0' 'INTERNAL_ONLY'
+$script:FixturePluginList = [pscustomobject]@{ installed = @(); available = @() }
+$withheldOutput = @(Test-AllBundledMarketplacePluginsAvailableWithCodexCli $stableRoot $installedRoot 6>&1)
+$withheldText = ($withheldOutput | ForEach-Object { [string]$_ }) -join [Environment]::NewLine
+if ($withheldText -notmatch 'bundled plugins withheld from the marketplace mirror \(INTERNAL_ONLY\): fixture') {
+  throw "An INTERNAL_ONLY descriptor absent from the CLI was not reported as withheld: $withheldText"
+}
+
+# The exemption must be scoped to the policy, not blanket-skip missing plugins.
+Set-FixtureMarketplace $installedRoot '2.0.0'
+Set-FixtureMarketplace $stableRoot '2.0.0'
+$script:FixturePluginList = [pscustomobject]@{ installed = @(); available = @() }
+Assert-ThrowsLike {
+  Test-AllBundledMarketplacePluginsAvailableWithCodexCli $stableRoot $installedRoot
+} '*bundled plugin is not discoverable as installed or available: fixture@openai-bundled*'
 
 Write-Output "Bundled plugin version-drift regression passed: $fixtureRoot"


### PR DESCRIPTION
Symptom

On Store build 26.901.6511.0, -VerifyAllBundledPluginsAvailable fails with:

    bundled plugin is not discoverable as installed or available:
    user-writing@openai-bundled

Nothing is actually broken. Re-running, reinstalling, or repairing does not help,
because the plugin can never appear.

Root cause

A bundled plugin descriptor may carry publicationPolicy INTERNAL_ONLY. Desktop
drops those descriptors when it builds the marketplace mirror that the CLI reads,
so the CLI cannot offer them as installed or available. The assertion required
CLI discovery for every bundled descriptor, so it treated that deliberate
withholding as a failure. 26.901.6511.0 ships user-writing 0.1.2 this way.

The excluded set was measured against the descriptors on disk and is exactly the
INTERNAL_ONLY set, which is what makes the policy the discriminating criterion
rather than a coincidence.

How the criterion changed

Only the CLI-discovery loop skips INTERNAL_ONLY descriptors. The descriptor-set
and version-drift comparisons are deliberately left alone: both of their sides
are raw package copies, where the policy has no effect, so narrowing them would
lose real coverage. Withheld plugins are named in the log rather than failing:

    bundled plugins withheld from the marketplace mirror (INTERNAL_ONLY): ...

The final success line now reads "all publishable bundled marketplace plugins
are available ...", and the two existing assertions that match that line were
updated with it.

Tests

Two cases were added to test-bundled-plugin-version-drift.ps1:

  - an INTERNAL_ONLY descriptor absent from the CLI must be reported as withheld
    and pass;
  - a plain descriptor absent from the CLI must still throw.

Reverting the fix turns the first case red, so the pair has discriminating power
rather than passing vacuously.

Verified on Store build 26.901.6511.0.
